### PR TITLE
FLUENT API: Added support for ContentTypes and Views for Lists

### DIFF
--- a/src/sharepoint/rest/web/lists/contenttypes/contenttypes.test.ts
+++ b/src/sharepoint/rest/web/lists/contenttypes/contenttypes.test.ts
@@ -1,0 +1,24 @@
+"use strict";
+
+import { expect } from "chai";
+import { ContentTypes } from "./ContentTypes";
+
+describe("ContentTypes", () => {
+    it("Should be an object", () => {
+        let contenttypes = new ContentTypes(["_api/web/lists/getByTitle('Tasks')"]);
+        expect(contenttypes).to.be.a("object");
+    });
+    describe("url", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/ContentTypes", () => {
+            let contenttypes = new ContentTypes(["_api/web/lists/getByTitle('Tasks')"]);
+            expect(contenttypes.url()).to.equal("_api/web/lists/getByTitle('Tasks')/ContentTypes");
+        });
+    });
+    describe("getById", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/ContentTypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')", () => {
+            let contenttypes = new Items(["_api/web/lists/getByTitle('Tasks')"]);
+            let ct = contenttypes.getById("0x0101000BB1B729DCB7414A9344ED650D3C05B3");
+            expect(ct.url()).to.equal("_api/web/lists/getByTitle('Tasks')/ContentTypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')");
+        });
+    });
+});

--- a/src/sharepoint/rest/web/lists/contenttypes/contenttypes.ts
+++ b/src/sharepoint/rest/web/lists/contenttypes/contenttypes.ts
@@ -1,0 +1,15 @@
+"use strict";
+
+/// <reference path="..\..\..\..\typings\main.d.ts" />
+
+import { Queryable } from "../../../Queryable";
+
+export class ContentTypes extends Queryable {
+    constructor(url: Array<string>) {
+        super(url, "/ContentTypes");
+    }
+    public getById(id: string) {
+        this._url.push(`(${id})`);
+        return this;
+    }
+}

--- a/src/sharepoint/rest/web/lists/lists.ts
+++ b/src/sharepoint/rest/web/lists/lists.ts
@@ -4,6 +4,8 @@
 
 import { Queryable } from "../../Queryable";
 import { Items } from "./Items/Items";
+import { Views } from "./Views/Views";
+import { ContentTypes } from "./ContentTypes/ContentTypes";
 
 export class Lists extends Queryable {
     constructor(url: Array<string>) {
@@ -12,11 +14,19 @@ export class Lists extends Queryable {
 
     public getByTitle(title: string) {
         this._url.push(`/getByTitle('${title}')`);
-        return jQuery.extend(this, { items: new Items(this._url) });
+        return jQuery.extend(this, {
+            contenttypes: new ContentTypes(this._url),
+            items: new Items(this._url),
+            views: new Views(this._url),
+        });
     }
 
     public getById(id: string) {
         this._url.push(`('${id}')`);
-        return jQuery.extend(this, { items: new Items(this._url) });
+        return jQuery.extend(this, {
+            contenttypes: new ContentTypes(this._url),
+            items: new Items(this._url),
+            views: new Views(this._url),
+        });
     }
 }

--- a/src/sharepoint/rest/web/lists/views/views.test.ts
+++ b/src/sharepoint/rest/web/lists/views/views.test.ts
@@ -1,0 +1,24 @@
+"use strict";
+
+import { expect } from "chai";
+import { Views } from "./Views";
+
+describe("Views", () => {
+    it("Should be an object", () => {
+        let views = new Views(["_api/web/lists/getByTitle('Tasks')"]);
+        expect(views).to.be.a("object");
+    });
+    describe("url", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/Views", () => {
+            let views = new Views(["_api/web/lists/getByTitle('Tasks')"]);
+            expect(views.url()).to.equal("_api/web/lists/getByTitle('Tasks')/Views");
+        });
+    });
+    describe("getById", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/Views(guid'7b7c777e-b749-4f58-a825-53084f2941b0')", () => {
+            let views = new Views(["_api/web/lists/getByTitle('Tasks')"]);
+            let view = views.getById("7b7c777e-b749-4f58-a825-53084f2941b0");
+            expect(view.url()).to.equal("_api/web/lists/getByTitle('Tasks')/Views(guid'7b7c777e-b749-4f58-a825-53084f2941b0')");
+        });
+    });
+});

--- a/src/sharepoint/rest/web/lists/views/views.ts
+++ b/src/sharepoint/rest/web/lists/views/views.ts
@@ -1,0 +1,15 @@
+"use strict";
+
+/// <reference path="..\..\..\..\typings\main.d.ts" />
+
+import { Queryable } from "../../../Queryable";
+
+export class Views extends Queryable {
+    constructor(url: Array<string>) {
+        super(url, "/Views");
+    }
+    public getById(id: string) {
+        this._url.push(`(guid'${id}')`);
+        return this;
+    }
+}


### PR DESCRIPTION
Support for ContentTypes and Views under Lists.

That's probably enough for Lists for now. We now support

- Items
- Views
- ContentTypes

Before doing more on the fluent api, I would like to know where to put usage documentation.