### PR TITLE
Add instruction to install gulp-cli globally

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,13 +22,15 @@ Unsure where to begin with working on the project? This guide is designed to get
 
 7. Install typings by typing the following code in your console `npm install -g typings`
 
-8. Now we need to fork and clone the git repository. This can be done using your [console](https://help.github.com/articles/fork-a-repo/) or using your preferred method.
+8. Install the gulp command line globally by typing the following code in your console `npm install -g gulp-cli`
 
-9. Once you have the code locally, navigate to the root of the project in your console. Type the following commands:
+9. Now we need to fork and clone the git repository. This can be done using your [console](https://help.github.com/articles/fork-a-repo/) or using your preferred method.
+
+10. Once you have the code locally, navigate to the root of the project in your console. Type the following commands:
 	1. `npm install` - installs all of the npm package dependencies (may take awhile the first time)
 	2. `typings install` - installs the required typings files as defined in typings.json 
 
-10. Type `gulp serve` and you should see the browser launch and an alert window display a random string of length 5.
+11. Type `gulp serve` and you should see the browser launch and an alert window display a random string of length 5.
 
 Because we are watching the files, any changes will be reflected in the served files after a new build is complete. You can point from a script tag in your SharePoint site to the http://localhost:3000 site to use the files. Any changes you make will be reflected thanks to the watched build.
 


### PR DESCRIPTION
This is in line with the gulp getting started guide found here: https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md