### PR TITLE
WIP/suggestion: Add DI framework and rewrite application to use this pattern

### DIFF
--- a/src/sharepoint/provisioning/logger/logger.ts
+++ b/src/sharepoint/provisioning/logger/logger.ts
@@ -1,30 +1,26 @@
-"use strict";
-
 /// <reference path="..\..\..\..\typings\main.d.ts" />
+"use strict";
 
 export class Logger {
     private isLoggerDefined;
-    private spacing;
-    private template;
     constructor() {
         this.isLoggerDefined = false;
         if (console && console.log) {
-           this.isLoggerDefined = true;
+            this.isLoggerDefined = true;
         }
-        this.spacing = "\t\t";
-        this.template = `{0} ${this.spacing} [{1}] ${this.spacing} [{2}] ${this.spacing} {3}`;
     }
     public info(object: string, message: string): void {
-        this.print(String.format(this.template, new Date(), object, "Information", message));
+        this.print(`${new Date()},\t\t[${object}], [Information], [${message}]`);
     }
+    // TODO this can be DRYd
     public debug(object: string, message: string): void {
-        this.print(String.format(this.template, new Date(), object, "Debug", message));
+        this.print(`${new Date()},\t\t[${object}], [Debug], [${message}]`);
     }
     public error(object: string, message: string): void {
-       this.print(String.format(this.template, new Date(), object, "Error", message));
+        this.print(`${new Date()},\t\t[${object}], [Error], [${message}]`);
     }
     private print(msg: string): void {
-         if (this.isLoggerDefined) {
+        if (this.isLoggerDefined) {
             console.log(msg);
         }
     }

--- a/src/sharepoint/provisioning/objecthandlers/objectpropertybagentries/objectpropertybagentries.test.ts
+++ b/src/sharepoint/provisioning/objecthandlers/objectpropertybagentries/objectpropertybagentries.test.ts
@@ -1,0 +1,24 @@
+/// <reference path="../../../../../typings/main.d.ts" />
+"use strict";
+
+import { ObjectPropertyBagEntries } from "./objectpropertybagentries";
+import * as Util from "../../../../utils/util";
+import { expect } from "chai";
+
+describe("ObjectPropertybagEntries", () => {
+    describe("ProvisionObjects", () => {
+        it("Should create contextual callback", (done) => {
+            let func = function(a) {
+                let promise = new ObjectPropertyBagEntries().ProvisionObjects(undefined);
+                expect(promise).to.be.instanceof(Promise);
+                done();
+            };
+            let ctx = { num: 1 };
+            let callback = Util.getCtxCallback(ctx, func, 7);
+            expect(callback).to.exist;
+            expect(callback).to.be.a("function");
+            // this call will update ctx var inside the callback
+            callback();
+        });
+    });
+});

--- a/src/sharepoint/provisioning/objecthandlers/objectpropertybagentries/objectpropertybagentries.ts
+++ b/src/sharepoint/provisioning/objecthandlers/objectpropertybagentries/objectpropertybagentries.ts
@@ -1,10 +1,10 @@
-// "use strict";
-// 
-// /// <reference path="..\schema\ipropertybagentry.d.ts" />
-// import { Promise } from "es6-promise";
-import { encodePropertyKey } from "../../../Util";
-import { ObjectHandlerBase } from "../ObjectHandlerBase/ObjectHandlerBase";
+/// <reference path="../../../../../typings/main.d.ts" />
+"use strict";
 
+import { Promise } from "es6-promise";
+import { encodePropertyKey } from "../../../../sharepoint/util";
+import { ObjectHandlerBase } from "../ObjectHandlerBase/ObjectHandlerBase";
+import { IPropertyBagEntry } from "../../schema/IPropertyBagEntry";
 
 export class ObjectPropertyBagEntries extends ObjectHandlerBase {
     constructor() {

--- a/src/sharepoint/provisioning/schema/IPropertyBagEntry.d.ts
+++ b/src/sharepoint/provisioning/schema/IPropertyBagEntry.d.ts
@@ -1,4 +1,4 @@
-interface IPropertyBagEntry {
+export interface IPropertyBagEntry {
     Key: string;
     Value: string;
     Indexed: boolean;


### PR DESCRIPTION
Logger was reliant on microsoft ajax (String.format). Refactored this to use typescript string itnerpolation.
Added beginning for tests for objectpropertybagentries. Right now it just tests that it returns a promise when ran inside a ctx from Util.

Questions: The import pattern used here. Is this the way to do it?

Note: The ```/// <reference``` must come before the 'use strict'; for it to work.