### PR TITLE
Coding Out Search Service - WIP & for review

### DIFF
--- a/buildtasks/copyRequireJsToSharePoint.js
+++ b/buildtasks/copyRequireJsToSharePoint.js
@@ -31,6 +31,8 @@ gulp.task("copyRequireJsToSharePoint", function() {
             username: global.settings.username,
             password: global.settings.password,
             siteUrl: global.settings.siteUrl,
-            folder: "Style%20Library/pnp"
+            folder: "Style%20Library/pnp",
+            checkin: true,
+            checkinType: 1
         }));
 });

--- a/buildtasks/serve.js
+++ b/buildtasks/serve.js
@@ -17,7 +17,8 @@ var gulp = require("gulp"),
 
 function setBrowserSync(buildServeTaskName) {
     browserSync.init({
-        server: global.PnPLocalServer.RootFolder
+        server: global.PnPLocalServer.RootFolder,
+        https: true
     });
 
     gulp.watch(global.TSWorkspace.Files, ["lint", buildServeTaskName]);

--- a/settings.example.1.js
+++ b/settings.example.1.js
@@ -1,0 +1,7 @@
+var settings = {
+    username: "develina.devsson@mydevtenant.onmicrosoft.com",
+    password: "pass@word1",
+    siteUrl: "https://mydevtenant.sharepoint.com/" 
+}
+
+module.exports = settings;

--- a/settings.example.js
+++ b/settings.example.js
@@ -1,7 +1,0 @@
-var settings = {
-    username: "develina.devsson@mydevtenant.onmicrosoft.com",
-    password: "pass@word1",
-    siteUrl: "https://mydevtenant.sharepoint.com/" 
-}
-
-module.exports = settings;

--- a/src/sharepoint/rest/search.ts
+++ b/src/sharepoint/rest/search.ts
@@ -1,0 +1,522 @@
+"use strict";
+
+import { Queryable} from "./Queryable";
+
+/**
+ * Describes the search API
+ * 
+ */
+export class Search extends Queryable {
+
+    /**
+     * Creates a new instance of the Search class
+     * 
+     * @param baseUrl The url for the search context
+     * @param query The SearchQuery object to execute
+     */
+
+    constructor(baseUrl: string | Queryable) {
+        super(baseUrl, "Search");
+    }
+
+    /**
+     * A string that contains the text for the search query. 
+     */
+    public QueryText: string = "*";
+
+    /**
+     * A string that contains the text that replaces the query text, as part of a query transform. 
+     */
+    public QueryTemplate: string = null;
+
+    /**
+     * A Boolean value that specifies whether the result tables that are returned for 
+     * the result block are mixed with the result tables that are returned for the original query. 
+     */
+    public EnableInterleaving: Boolean = true;
+
+    /**
+     * A Boolean value that specifies whether stemming is enabled. 
+     */
+    public EnableStemming: Boolean = true;
+
+    /**
+     * A Boolean value that specifies whether duplicate items are removed from the results. 
+     */
+    public TrimDuplicates: Boolean = true;
+
+    /**
+     * A Boolean value that specifies whether the exact terms in the search query are used to find matches, or if nicknames are used also. 
+     */
+    public EnableNicknames: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether the query uses the FAST Query Language (FQL).
+     */
+    public EnableFql: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether the phonetic forms of the query terms are used to find matches.
+     */
+    public EnablePhonetic: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether to perform result type processing for the query.
+     */
+    public BypassResultTypes: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether to return best bet results for the query.
+     * This parameter is used only when EnableQueryRules is set to true, otherwise it is ignored.
+     */
+    public ProcessBestBets: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether to enable query rules for the query.
+     */
+    public EnableQueryRules: Boolean = false;
+
+    /**
+     * A Boolean value that specifies whether to sort search results. 
+     */
+    public EnableSorting: Boolean = null;
+
+    /**
+     * Specifies whether to return block rank log information in the BlockRankLog property of the interleaved result table. 
+     * A block rank log contains the textual information on the block score and the documents that were de-duplicated.
+     */
+    public GenerateBlockRankLog: Boolean = null;
+
+    /**
+     * The result source ID to use for executing the search query.  
+     */
+    public SourceId: string = null;
+
+    /**
+     * The ID of the ranking model to use for the query.  
+     */
+    public RankingModelId: string = null;
+
+    /**
+     * The first row that is included in the search results that are returned. 
+     * You use this parameter when you want to implement paging for search results.
+     */
+    public StartRow: Number = null;
+
+    /**
+     * The maximum number of rows overall that are returned in the search results. 
+     * Compared to RowsPerPage, RowLimit is the maximum number of rows returned overall.
+     */
+    public RowLimit: Number = null;
+
+    /**
+     * The maximum number of rows to return per page. 
+     * Compared to RowLimit, RowsPerPage refers to the maximum number of rows to return per page,
+     * and is used primarily when you want to implement paging for search results.
+     */
+    public RowsPerPage: Number = null;
+
+    /**
+     * The managed properties to return in the search results.  
+     */
+    public SelectProperties: string[] = [];
+
+    /**
+     * The locale ID (LCID) for the query.  
+     */
+    public Culture: Number = null;
+
+    /**
+     * The set of refinement filters used when issuing a refinement query (FQL)  
+     */
+    public RefinementFilters: string[] = [];
+
+     /**
+      * The set of refiners to return in a search result.
+      */
+    public Refiners: string[] = [];
+
+    /**
+     * The additional query terms to append to the query.
+     */
+    public HiddenConstraints: string = null;
+
+    /**
+     * The list of properties by which the search results are ordered.
+     */
+    public SortList: Sort[] = [];
+
+    /**
+     * The amount of time in milliseconds before the query request times out. 
+     */
+    public Timeout: Number = 30000;
+
+    /**
+     * The properties to highlight in the search result summary when the property value matches the search terms entered by the user.
+     */
+    public HithighlightedProperties: string[] = [];
+
+    /**
+     * The type of the client that issued the query.
+     */
+    public ClientType: string = null;
+
+    /** 
+     * The GUID for the user who submitted the search query.
+     */
+    public PersonalizationData: string = null;
+
+    /** 
+     * The URL for the search results page.
+     */
+    public ResultsURL: string = null;
+
+    /** 
+     * Custom tags that identify the query. You can specify multiple query tags
+     */
+    public QueryTag: string[] = [];
+
+    // TODO: Properties
+
+    // TODO: ReorderingRules
+
+    /**
+     *  A Boolean value that specifies whether to return personal favorites with the search results.
+     */
+    public ProcessPersonalFavorites: Boolean = null;
+
+    /**
+     * The location of the queryparametertemplate.xml file. This file is used to enable anonymous users to make Search REST queries.
+     */
+    public QueryTemplatePropertiesUrl: string = null;
+
+    /**
+     * The number of properties to show hit highlighting for in the search results.
+     */
+    public HitHighlightedMultivaluePropertyLimit: Number = null;
+
+    /**
+     * A Boolean value that specifies whether the hit highlighted properties can be ordered.
+     */
+    public EnableOrderingHitHighlightedProperty: Boolean = null;
+
+    /**
+     * The managed properties that are used to determine how to collapse individual search results. 
+     * Results are collapsed into one or a specified number of results if they match any of the individual collapse specifications. 
+     * In a collapse specification, results are collapsed if their properties match all individual properties in the collapse specification.
+     */
+    public CollapseSpecification: String = null;
+
+    /**
+     * The locale identifier (LCID) of the user interface
+     */
+    public UIlanguage: Number = null;
+
+    /**
+     * The preferred number of characters to display in the hit-highlighted summary generated for a search result.
+     */
+    public DesiredSnippetLength: Number = null;
+
+    /**
+     * The maximum number of characters to display in the hit-highlighted summary generated for a search result.
+     */
+    public MaxSnippetLength: Number = null;
+
+    /**
+     * The number of characters to display in the result summary for a search result.
+     */
+    public SummaryLength: Number = null;
+
+    /**
+     * .......
+     * @returns Promise
+     */
+    public getSearchResults(): Promise<any> {
+
+        let q = new Queryable("_api/search/query");
+
+        q.query.add("querytext", `'${this.QueryText}'`);
+
+        if (this.QueryTemplate) {
+            q.query.add("QueryTemplate", this.QueryTemplate);
+        }
+
+        q.query.add("EnableInterleaving", this.EnableInterleaving.toString());
+        q.query.add("EnableStemming", this.EnableStemming.toString());
+        q.query.add("TrimDuplicates", this.TrimDuplicates.toString());
+        q.query.add("EnableNicknames", this.EnableNicknames.toString());
+        q.query.add("EnablePhonetic", this.EnablePhonetic.toString());
+        q.query.add("EnableFql", this.EnableFql.toString());
+        q.query.add("BypassResultTypes", this.BypassResultTypes.toString());
+        q.query.add("EnableQueryRules", this.EnableQueryRules.toString());
+
+        if (this.ProcessPersonalFavorites) {
+            q.query.add("ProcessPersonalFavorites", this.ProcessPersonalFavorites.toString());
+        }
+
+        if (this.EnableQueryRules === true) {
+            q.query.add("ProcessBestBets", this.ProcessBestBets.toString());
+        }
+
+        if (this.SourceId) {
+            q.query.add("SourceId", this.SourceId);
+        }
+
+        if (this.RankingModelId) {
+            q.query.add("RankingModelId", this.RankingModelId);
+        }
+
+        if (this.StartRow) {
+            q.query.add("StartRow", this.StartRow.toString());
+        }
+
+        if (this.RowLimit) {
+            q.query.add("RowLimit", this.RowLimit.toString());
+        }
+
+        if (this.RowsPerPage) {
+            q.query.add("RowsPerPage", this.RowsPerPage.toString());
+        }
+
+        if (this.SelectProperties.length > 0) {
+            q.query.add("SelectProperties", `'${this.SelectProperties.toString()}'`);
+        }
+
+        if (this.Culture) {
+            q.query.add("Culture", this.Culture.toString());
+        }
+
+        if (this.RefinementFilters.length > 0) {
+            q.query.add("RefinementFilters", `'${this.RefinementFilters.toString()}'`);
+        }
+
+        if (this.Refiners.length > 0) {
+            q.query.add("Refiners", `'${this.Refiners.toString()}'`);
+        }
+
+        if (this.HiddenConstraints) {
+            q.query.add("HiddenConstraints", this.HiddenConstraints);
+        }
+
+        if (this.SortList.length > 0) {
+            let sort: string;
+            sort = "'";
+            for (let sortItem of this.SortList) {
+                sort += `${sortItem.Property}:${sortItem.Direction},`;
+            }
+            sort += "'";
+
+            q.query.add("SortList", sort);
+
+            // set sorting to true, as SortList has been defined
+            this.EnableSorting = true;
+        }
+
+        if (this.ClientType) {
+            q.query.add("ClientType", this.ClientType.toString());
+        }
+
+        q.query.add("Timeout", this.Timeout.toString());
+
+        if (this.HithighlightedProperties.length > 0) {
+            q.query.add("HithighlightedProperties", `'${this.HithighlightedProperties.toString()}'`);
+        }
+
+        if (this.PersonalizationData) {
+            q.query.add("PersonalizationData", this.PersonalizationData.toString());
+        }
+
+        if (this.ResultsURL) {
+            q.query.add("PersonalizationData", this.ResultsURL.toString());
+        }
+
+        // query tags are separated by semicolon
+        if (this.QueryTag.length > 0) {
+            let queryTag: string;
+            queryTag = "'";
+            for (let sortItem of this.QueryTag) {
+                queryTag += `${sortItem};`;
+            }
+            queryTag += "'";
+
+            q.query.add("QueryTag", queryTag);
+        }
+
+        if (this.QueryTag.length > 0) {
+            q.query.add("QueryTag", `'${this.Refiners.toString()}'`.replace(",", ";"));
+        }
+
+        if (this.QueryTemplatePropertiesUrl) {
+            q.query.add("QueryTemplatePropertiesUrl", this.QueryTemplatePropertiesUrl);
+        }
+
+        if (this.HitHighlightedMultivaluePropertyLimit) {
+            q.query.add("HitHighlightedMultivaluePropertyLimit", this.HitHighlightedMultivaluePropertyLimit.toString());
+        }
+
+        if (this.EnableOrderingHitHighlightedProperty) {
+            q.query.add("EnableOrderingHitHighlightedProperty", this.EnableOrderingHitHighlightedProperty.toString());
+        }
+
+        if (this.CollapseSpecification) {
+            q.query.add("CollapseSpecification", this.CollapseSpecification.toString());
+        }
+
+        if (this.EnableSorting) {
+            q.query.add("EnableSorting", this.EnableSorting.toString());
+        }
+
+        if (this.GenerateBlockRankLog) {
+            q.query.add("GenerateBlockRankLog", this.GenerateBlockRankLog.toString());
+        }
+
+        if (this.UIlanguage) {
+            q.query.add("UIlanguage", this.UIlanguage.toString());
+        }
+
+        if (this.DesiredSnippetLength) {
+            q.query.add("DesiredSnippetLength", this.DesiredSnippetLength.toString());
+        }
+
+        if (this.MaxSnippetLength) {
+            q.query.add("MaxSnippetLength", this.MaxSnippetLength.toString());
+        }
+
+        if (this.SummaryLength) {
+            q.query.add("SummaryLength", this.SummaryLength.toString());
+        }
+
+        return q.get().then((data) => {
+            return new SearchResults(data);
+        });
+
+    }
+
+    /**
+     * //TODO: implement
+     * @returns Promise
+     */
+    public getSearchResultsByPOST(): Promise<any> {
+        let q = new Queryable("_api/search/postquery");
+
+        return q.get();
+
+        // TODO reordering rules in POST
+    }
+
+}
+
+/**
+ * Describes the SearchResult class 
+ */
+
+export class SearchResults {
+
+    /**
+     * Creates a new instance of the SearchResult class
+     * 
+     */
+    constructor( response: any) {
+        this.PrimarySearchResults = this.formatSearchResults(response.PrimaryQueryResult.RelevantResults.Table.Rows);
+        this.RawSearchResults = response;
+    }
+
+    public PrimarySearchResults: any = null;
+    public RawSearchResults: any = null;
+
+    /**
+     * Formats a search results array
+     * 
+     * @param rawResults The array to process 
+     */
+    protected formatSearchResults(rawResults: Array<any>): SearchResult[] {
+
+        let results = new  Array<SearchResult>();
+
+        for (let i of rawResults) {
+            results.push(new SearchResult(i.Cells));
+        }
+        return results;
+
+    }
+
+}
+
+export class SearchResult {
+
+    /**
+     * Creates a new instance of the SearchResult class
+     * 
+     */
+    constructor( item: Array<any>) {
+
+        for (let i of item) {
+            this[i.Key] = i.Value;
+        }
+    }
+}
+
+/**
+ * Defines how search results are sorted.
+ */
+export interface Sort {
+    /**
+     * The name for a property by which the search results are ordered.
+     */
+    Property: string;
+
+    /**
+     * The direction in which search results are ordered.
+     */
+    Direction: SortDirection;
+}
+
+export enum SortDirection {
+    Ascending = 0,
+    Descending = 1,
+    FQLFormula = 2
+}
+
+/**
+ * Defines how search results are sorted.
+ */
+export interface QueryProperty {
+    // TODO: define this interface
+}
+
+/**
+ * Specifies the type value for the property
+ */
+export enum QueryPropertyValueType {
+    None = 0,
+    StringType = 1,
+    Int32TYpe = 2,
+    BooleanType = 3,
+    StringArrayType = 4,
+    UnSupportedType	= 5
+}
+
+/**
+ * 
+ */
+export enum ReorderingRuleMatchType {
+    ResultContainsKeyword = 0,
+    TitleContainsKeyword = 1,
+    TitleMatchesKeyword = 2,
+    UrlStartsWith = 3,
+    UrlExactlyMatches = 4,
+    ContentTypeIs = 5,
+    FileExtensionMatches = 6,
+    ResultHasTag = 7,
+    ManualCondition = 8
+}
+
+/*
+
+TODO: Properties of Search to implement in the interface
+
+UIlanguage
+DesiredSnippetLength
+MaxSnippetLength
+SummaryLength
+*/

--- a/src/sharepoint/rest/webs.ts
+++ b/src/sharepoint/rest/webs.ts
@@ -2,6 +2,7 @@
 
 import { Queryable, QueryableInstance, QueryableCollection } from "./Queryable";
 import { QueryableSecurable } from "./QueryableSecurable";
+import { Search } from "./search";
 import { Lists } from "./lists";
 import { RoleAssignments } from "./roleAssignments";
 import { Navigation } from "./navigation";
@@ -111,6 +112,14 @@ export class Web extends QueryableSecurable {
      */
     public get navigation(): Navigation {
         return new Navigation(this);
+    }
+
+    /**
+     * Executes a search against this web context
+     * 
+     */
+    public get search(): Search {
+        return new Search(this);
     }
 
     /**


### PR DESCRIPTION
## Issue 59 - WIP!!!

This is my WIP for #59. I am interested in feedback on 
1. approach so far
2. further enhancements 
3. other things people would like to see in the returned object (looking at you @mike-morrison :-)) 

This is *not* intended to be a final release, it's really just for others to review my approach. I have tried to ensure that the properties exposed match the properties available in the API (including settings defaults, where they are defined in the API). 

There are a few exceptions, `SelectProperties` for example is a string in the GET API, but as a consumer it would make for a poor experience if they have to type "Title,Author", better for them to build an array, as shown below. 

### Usage

To use this in the browser, build as documented and (assuming you have a SharePoint page set up) run the following in the console. You'll also be able to better examine the returned object

```javascript
var s = pnp.sharepoint.rest.web.search;
s.QueryText = "test"
// s.SelectProperties = ["Title", "Author", "Byline"]

s.getSearchResults().then(function(data){
    console.log(data);
;});

```

This returns the following

```json
{
   "RawSearchResults":"THEACTUALRESULTSFROMSHAREPOINT",
   "PrimarySearchResults":[
      {
         "Title":"Test",
         "Author":"Tobias West",
         "Byline":"This is the article byline!"
      },
     {
         "Title":"Test 2",
         "Author":"Tobias West",
         "Byline":"This is the article 2 byline!"
      },
   ]
}
}
```

### TODO

- write tests, ensure code coverage is appropriate document
- handle more advanced scenarios in the returned data set, such as paging, grouping, SecondaryQueryResults etc. 
- handle POST @patrick-rodgers  I was considering whether `Queryable` should have a public post method which processes the same `query` collection to build the POST body, thoughts?
- Sort object & implementation
- A few other, rarely used properties which I need to R&D more. 

### Final notes

There are a few files in the PR I shouldn't have included, but since we're not integrating I'm not too worried about that. The final PR would be tidy with appropriate commit messages :)