### PR TITLE
update to support retry on server unavailable or throttled request responses

### DIFF
--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -60,7 +60,46 @@ export class HttpClient {
     }
 
     public fetchRaw(url: string, options: any = {}): Promise<Response> {
-        return this._impl.fetch(url, options);
+
+        let retry = (ctx): void => {
+
+            this._impl.fetch(url, options).then((response) => ctx.resolve(response)).catch((response) => {
+
+                // grab our current delay
+                let delay = ctx.delay;
+
+                // Check if request was throttled - http status code 429 
+                // Check is request failed due to server unavailable - http status code 503 
+                if (response.status !== 429 && response.status !== 503) {
+                    ctx.reject(response);
+                }
+
+                // Increment our counters.
+                ctx.delay *= 2;
+                ctx.attempts++;
+
+                // If we have exceeded the retry count, reject.
+                if (ctx.retryCount <= ctx.attempts) {
+                    ctx.reject(response);
+                }
+
+                // Set our retry timeout for {delay} milliseconds.
+                setTimeout(Util.getCtxCallback(this, retry, ctx), delay);
+            });
+        };
+
+        return new Promise((resolve, reject) => {
+
+            let retryContext = {
+                attempts: 0,
+                delay: 100,
+                reject: reject,
+                resolve: resolve,
+                retryCount: 7,
+            };
+
+            retry.call(this, retryContext);
+        });
     }
 
     public get(url: string, options: any = {}): Promise<Response> {

--- a/src/sharepoint/rest/lists.ts
+++ b/src/sharepoint/rest/lists.ts
@@ -88,14 +88,16 @@ export class Lists extends QueryableCollection {
     public ensure(title: string, description = "", template = 100, enableContentTypes = false, additionalSettings: TypedHash<string | number | boolean> = {}): Promise<ListEnsureResult> {
 
         return new Promise((resolve, reject) => {
-            
+
             let list: List = this.getByTitle(title);
 
             list.get().then((d) => resolve({ created: false, list: list, data: d })).catch(() => {
 
-                this.add(title, description, template, enableContentTypes, additionalSettings).then((r) => resolve({ created: true, list: this.getByTitle(title), data: r.data }));
+                this.add(title, description, template, enableContentTypes, additionalSettings).then((r) => {
+                    resolve({ created: true, list: this.getByTitle(title), data: r.data })
+                });
 
-            }).catch(() => reject());
+            }).catch((e) => reject(e));
         });
     }
     /*tslint:enable */


### PR DESCRIPTION
Does a retry inline with the same logic as the CSOM library on response status 429 and 503. Request retry follows curve, taking longer each pass as shown:

![retry testing](http://i.imgur.com/MmXYmlD.png)
