### PR TITLE
pnp.d.ts now gets created with member comments present

### DIFF
--- a/buildtasks/package.js
+++ b/buildtasks/package.js
@@ -37,7 +37,7 @@ function packageDefinitions() {
 
     // create a project specific to our typings build and specify the outFile. This will result
     // in a single pnp.d.ts file being creating and piped to the typings folder
-    var typingsProject = tsc.createProject('tsconfig.json', { "declaration": true, "outFile": "pnp.js" });
+    var typingsProject = tsc.createProject('tsconfig.json', { "declaration": true, "outFile": "pnp.js", "removeComments" : false });
 
     return gulp.src(src)
         .pipe(tsc(typingsProject))


### PR DESCRIPTION
The dist/pnp.d.ts TypeScript definition was getting created without member JSDoc comments present, which created a less than desired intellisense experience in code editors.

This custom gulp task fix just adds the appropriate setting to the TypeScript compiler to preserve the comments during the generation of the dist/pnp.d.ts TypeScript definition.