### PR TITLE
Included a regex replace in lists.getById() in order to be able to use e.g. _spPageContextInfo.pageListId directly

### DIFF
--- a/src/sharepoint/rest/lists.ts
+++ b/src/sharepoint/rest/lists.ts
@@ -41,7 +41,7 @@ export class Lists extends QueryableCollection {
      */
     public getById(id: string): List {
         let list = new List(this);
-        list.concat(`(guid'${id.replace(/[^a-zA-Z0-9_-]/g,"")}')`);
+        list.concat(`(${id})`);
         return list;
     }
 

--- a/src/sharepoint/rest/lists.ts
+++ b/src/sharepoint/rest/lists.ts
@@ -41,7 +41,7 @@ export class Lists extends QueryableCollection {
      */
     public getById(id: string): List {
         let list = new List(this);
-        list.concat(`(guid'${id}')`);
+        list.concat(`(guid'${id.replace(/[^a-zA-Z0-9_-]/g,"")}')`);
         return list;
     }
 

--- a/tests/sharepoint/rest/lists.test.ts
+++ b/tests/sharepoint/rest/lists.test.ts
@@ -26,15 +26,15 @@ describe("Lists", () => {
         });
     });
     describe("getById", () => {
-        it("Should return _api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')", () => {
+        it("Should return _api/web/lists(4FC65058-FDDE-4FAD-AB21-2E881E1CF527)", () => {
             let list = lists.getById("4FC65058-FDDE-4FAD-AB21-2E881E1CF527");
-            expect(list.toUrl()).to.equal("_api/web/lists(guid'4FC65058-FDDE-4FAD-AB21-2E881E1CF527')");
+            expect(list.toUrl()).to.equal("_api/web/lists(4FC65058-FDDE-4FAD-AB21-2E881E1CF527)");
         });
     });
     describe("getById with {}", () => {
-        it("Should return _api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')", () => {
+        it("Should return _api/web/lists({4FC65058-FDDE-4FAD-AB21-2E881E1CF527})", () => {
             let list = lists.getById("{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}");
-            expect(list.toUrl()).to.equal("_api/web/lists(guid'4FC65058-FDDE-4FAD-AB21-2E881E1CF527')");
+            expect(list.toUrl()).to.equal("_api/web/lists({4FC65058-FDDE-4FAD-AB21-2E881E1CF527})");
         });
     });
 });

--- a/tests/sharepoint/rest/lists.test.ts
+++ b/tests/sharepoint/rest/lists.test.ts
@@ -31,6 +31,12 @@ describe("Lists", () => {
             expect(list.toUrl()).to.equal("_api/web/lists(guid'4FC65058-FDDE-4FAD-AB21-2E881E1CF527')");
         });
     });
+    describe("getById with {}", () => {
+        it("Should return _api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')", () => {
+            let list = lists.getById("{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}");
+            expect(list.toUrl()).to.equal("_api/web/lists(guid'4FC65058-FDDE-4FAD-AB21-2E881E1CF527')");
+        });
+    });
 });
 
 describe("List", () => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | not sure :)
| New feature?    | yes
| New sample?      | no
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Included a regex replace in lists.getById() in order to be able to use e.g. spPageContextInfo.pageListId directly. {} are replaced from the string.

Included a test.