### PR TITLE
normalizing module names in import statements

### DIFF
--- a/src/pnp.ts
+++ b/src/pnp.ts
@@ -1,10 +1,10 @@
 "use strict";
 
-import { Util } from "./utils/Util";
-import { PnPClientStorage } from "./utils/Storage";
+import { Util } from "./utils/util";
+import { PnPClientStorage } from "./utils/storage";
 import { Settings } from "./configuration/configuration";
 import { Logger } from "./utils/logging";
-import { Rest } from "./SharePoint/Rest/rest";
+import { Rest } from "./sharepoint/rest/rest";
 
 /**
  * Root class of the Patterns and Practices namespace, provides an entry point to the library

--- a/src/sharepoint/rest/contenttypes.ts
+++ b/src/sharepoint/rest/contenttypes.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableCollection, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableCollection, QueryableInstance } from "./queryable";
 
 /**
  * Describes a collection of content types

--- a/src/sharepoint/rest/files.ts
+++ b/src/sharepoint/rest/files.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableCollection, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableCollection, QueryableInstance } from "./queryable";
 import { Item } from "./items";
 
 /**

--- a/src/sharepoint/rest/folders.ts
+++ b/src/sharepoint/rest/folders.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableCollection, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableCollection, QueryableInstance } from "./queryable";
 import { Files } from "./files";
 import { Item } from "./items";
 

--- a/src/sharepoint/rest/items.ts
+++ b/src/sharepoint/rest/items.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import { Queryable, QueryableCollection, QueryableInstance } from "./Queryable";
-import { QueryableSecurable } from "./QueryableSecurable";
+import { Queryable, QueryableCollection, QueryableInstance } from "./queryable";
+import { QueryableSecurable } from "./queryablesecurable";
 import { Folder } from "./folders";
 import { ContentType } from "./contenttypes";
 import { TypedHash } from "../../collections/collections";

--- a/src/sharepoint/rest/lists.ts
+++ b/src/sharepoint/rest/lists.ts
@@ -5,7 +5,7 @@ import { Views, View } from "./views";
 import { ContentTypes } from "./contenttypes";
 import { Fields } from "./fields";
 import { Queryable, QueryableCollection } from "./queryable";
-import { QueryableSecurable } from "./QueryableSecurable";
+import { QueryableSecurable } from "./queryablesecurable";
 import { Util } from "../../utils/util";
 import { TypedHash } from "../../collections/collections";
 import * as Types from "./types";

--- a/src/sharepoint/rest/queryableSecurable.ts
+++ b/src/sharepoint/rest/queryableSecurable.ts
@@ -1,6 +1,6 @@
 
 import { RoleAssignments } from "./roles";
-import { Queryable, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableInstance } from "./queryable";
 
 export class QueryableSecurable extends QueryableInstance {
 

--- a/src/sharepoint/rest/quicklaunch.ts
+++ b/src/sharepoint/rest/quicklaunch.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable } from "./Queryable";
+import { Queryable } from "./queryable";
 
 /**
  * Describes the quick launch navigation

--- a/src/sharepoint/rest/search.ts
+++ b/src/sharepoint/rest/search.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableInstance } from "./queryable";
 
 
 /**

--- a/src/sharepoint/rest/site.ts
+++ b/src/sharepoint/rest/site.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableInstance } from "./queryable";
 import { Web } from "./webs";
 import { UserCustomActions } from "./usercustomactions";
 

--- a/src/sharepoint/rest/sitegroups.ts
+++ b/src/sharepoint/rest/sitegroups.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance, QueryableCollection } from "./Queryable";
+import { Queryable, QueryableInstance, QueryableCollection } from "./queryable";
 import {SiteUser, SiteUsers} from "./siteusers";
 import { Util } from "../../utils/util";
 

--- a/src/sharepoint/rest/siteusers.ts
+++ b/src/sharepoint/rest/siteusers.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance, QueryableCollection } from "./Queryable";
+import { Queryable, QueryableInstance, QueryableCollection } from "./queryable";
 import { SiteGroups } from "./sitegroups";
 import { Util } from "../../utils/util";
 import { UserIdInfo, PrincipalType } from "./types";

--- a/src/sharepoint/rest/topnavigationbar.ts
+++ b/src/sharepoint/rest/topnavigationbar.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableInstance } from "./queryable";
 
 /**
  * Describes the top navigation on the site

--- a/src/sharepoint/rest/userprofiles.ts
+++ b/src/sharepoint/rest/userprofiles.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableInstance, QueryableCollection } from "./Queryable";
+import { Queryable, QueryableInstance, QueryableCollection } from "./queryable";
 import * as Types from "./types";
 import * as FileUtil from "../../utils/files";
 import { ODataValue } from "./odata";

--- a/src/sharepoint/rest/views.ts
+++ b/src/sharepoint/rest/views.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Queryable, QueryableCollection, QueryableInstance } from "./Queryable";
+import { Queryable, QueryableCollection, QueryableInstance } from "./queryable";
 import { TypedHash } from "../../collections/collections";
 import { Util } from "../../utils/util";
 

--- a/src/sharepoint/rest/webs.ts
+++ b/src/sharepoint/rest/webs.ts
@@ -1,11 +1,11 @@
 "use strict";
 
-import { Queryable, QueryableCollection } from "./Queryable";
-import { QueryableSecurable } from "./QueryableSecurable";
+import { Queryable, QueryableCollection } from "./queryable";
+import { QueryableSecurable } from "./queryablesecurable";
 import { Lists } from "./lists";
 import { Navigation } from "./navigation";
 import { SiteGroups } from "./sitegroups";
-import { ContentTypes } from "./contentTypes";
+import { ContentTypes } from "./contenttypes";
 import { Folders, Folder } from "./folders";
 import { RoleDefinitions } from "./roles";
 import { File } from "./files";

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Util } from "./Util";
+import { Util } from "./util";
 
 /**
  * A wrapper class to provide a consistent interface to browser based storage


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

When testing in webpack warnings were noted that different casing was used in the various import statements. This PR normalizes these to all lowercase which will remove these warnings in the future.
