### PR TITLE
Update to support config of headers sent in requests (issue #125)

### DIFF
--- a/server-root/scratchpad.js
+++ b/server-root/scratchpad.js
@@ -26,16 +26,15 @@ require(["pnp"], function (pnp) {
         });
     }
 
-// accept: application/json; odata=nometadata
-// application/json; odata=verbose
-
     pnp.setup({
         headers: {
             "Accept": "application/json; odata=verbose"
         }
     });
 
-    pnp.sp.web.get().then(show);
+    pnp.sp.web.lists.getByTitle("Config3").items.add({ Title: "Another Item" }).then(function (result) {
+        show(result.data);
+    });
 
     // pnp.sp.web.lists.getByTitle("Config3").items.get().then(show);
 

--- a/server-root/scratchpad.js
+++ b/server-root/scratchpad.js
@@ -26,8 +26,19 @@ require(["pnp"], function (pnp) {
         });
     }
 
-    // pnp.sp.web.get().then(show);
-    
+// accept: application/json; odata=nometadata
+// application/json; odata=verbose
+
+    pnp.setup({
+        headers: {
+            "Accept": "application/json; odata=verbose"
+        }
+    });
+
+    pnp.sp.web.get().then(show);
+
+    // pnp.sp.web.lists.getByTitle("Config3").items.get().then(show);
+
     // pnp.sp.web.lists.getByTitle("Config3").items.orderBy("Title").top(1).getPaged().then(d => {
     //     show(d);
     //     d.getNext().then(d => show(d));

--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -1,0 +1,34 @@
+import { TypedHash } from "../collections/collections";
+
+export interface LibraryConfiguration {
+    headers?: TypedHash<string>;
+}
+
+export class RuntimeConfigImpl {
+
+    constructor() {
+        this._headers = null;
+    }
+
+    private _headers: TypedHash<string>;
+
+    public set(config: LibraryConfiguration): void {
+
+        // add any headers that are supplied
+        if (config.hasOwnProperty("headers")) {
+            this._headers = config.headers;
+        }
+    }
+
+    public get headers(): TypedHash<string> {
+        return this._headers;
+    }
+}
+
+let _runtimeConfig = new RuntimeConfigImpl();
+
+export let RuntimeConfig = _runtimeConfig;
+
+export function setRuntimeConfig(config: LibraryConfiguration): void {
+    _runtimeConfig.set(config);
+}

--- a/src/net/DigestCache.ts
+++ b/src/net/DigestCache.ts
@@ -3,6 +3,7 @@
 import { Dictionary } from "../collections/collections";
 import { HttpClient } from "./httpClient";
 import { Util } from "../utils/util";
+import { ODataDefaultParser } from "../sharepoint/rest/odata";
 
 export class CachedDigest {
     public expiration: Date;
@@ -30,13 +31,14 @@ export class DigestCache {
             cache: "no-cache",
             credentials: "same-origin",
             headers: {
-                "Accept": "application/json",
+                "Accept": "application/json;odata=verbose",
                 "Content-type": "application/json;odata=verbose;charset=utf-8",
             },
             method: "POST",
-        }).then(function(response) {
-            return response.json();
-        }).then(function(data) {
+        }).then(function (response) {
+            let parser = new ODataDefaultParser();
+            return parser.parse(response).then((d: any) => d.GetContextWebInformation);
+        }).then(function (data) {
             let newCachedDigest = new CachedDigest();
             newCachedDigest.value = data.FormDigestValue;
             let seconds = data.FormDigestTimeoutSeconds;

--- a/src/pnp.ts
+++ b/src/pnp.ts
@@ -5,6 +5,7 @@ import { PnPClientStorage } from "./utils/storage";
 import { Settings } from "./configuration/configuration";
 import { Logger } from "./utils/logging";
 import { Rest } from "./sharepoint/rest/rest";
+import { setRuntimeConfig, LibraryConfiguration } from "./configuration/pnplibconfig";
 
 /**
  * Root class of the Patterns and Practices namespace, provides an entry point to the library
@@ -35,6 +36,11 @@ export const config = new Settings();
  */
 export const log = Logger;
 
+/**
+ * Allows for the configuration of the library
+ */
+export const setup: (config: LibraryConfiguration) => void = setRuntimeConfig;
+
 // creating this class instead of directly assigning to default fixes issue #116
 let Def = {
     /**
@@ -45,6 +51,10 @@ let Def = {
      * Global logging instance to which subscribers can be registered and messages written
      */
     log: log,
+    /**
+     * Provides access to local and session storage
+     */
+    setup: setup,
     /**
      * Provides access to the REST interface
      */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | Yes
| New sample?      | No
| Related issues?  | fixes #125 

#### What's in this Pull Request?

This PR contains an update to provide global configuration of the headers sent with each REST request. This resolves #125 by allowing a developer to set "application/json; odata=verbose" for the accept header as shown below:

```
    pnp.setup({
        headers: {
            "Accept": "application/json; odata=verbose"
        }
    });

    pnp.sp.web.get().then(show);
```

This also enables the scenario of setting an authentication header using a previously retrieved bearer token - or any other headers that may be needed for a given solution. Currently "headers" is the only configurable property but we will add additional configuration options as they become required or found to provide some benefit.

