### PR TITLE
CORS support

### DIFF
--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -2,15 +2,18 @@ import { TypedHash } from "../collections/collections";
 
 export interface LibraryConfiguration {
     headers?: TypedHash<string>;
+    useSPRequestExecutor?: boolean;
 }
 
 export class RuntimeConfigImpl {
+    private _headers: TypedHash<string>;
+
+    private _useSPRequestExecutor: boolean;
 
     constructor() {
         this._headers = null;
+        this._useSPRequestExecutor = false;
     }
-
-    private _headers: TypedHash<string>;
 
     public set(config: LibraryConfiguration): void {
 
@@ -18,10 +21,19 @@ export class RuntimeConfigImpl {
         if (config.hasOwnProperty("headers")) {
             this._headers = config.headers;
         }
+
+        // set SP.RequestExecutor if configured
+        if (config.hasOwnProperty("useSPRequestExecutor")) {
+            this._useSPRequestExecutor = config.useSPRequestExecutor;
+        }
     }
 
     public get headers(): TypedHash<string> {
         return this._headers;
+    }
+
+      public get useSPRequestExecutor(): boolean {
+        return this._useSPRequestExecutor;
     }
 }
 

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -4,14 +4,22 @@ import { FetchClient } from "./fetchClient";
 import { DigestCache } from "./digestCache";
 import { Util } from "../utils/util";
 import { RuntimeConfig } from "../configuration/pnplibconfig";
+import {SPRequestExecutorClient} from "./SPRequestExecutorClient";
 
 export class HttpClient {
+    private _digestCache: DigestCache;
 
-    constructor(private _impl = new FetchClient()) {
+    private _impl: HttpClientImpl;
+
+    constructor() {
+        if (RuntimeConfig.useSPRequestExecutor) {
+            this._impl = new SPRequestExecutorClient();
+        } else {
+            this._impl = new FetchClient();
+        }
+
         this._digestCache = new DigestCache(this);
     }
-
-    private _digestCache: DigestCache;
 
     public fetch(url: string, options: any = {}): Promise<Response> {
 

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -1,0 +1,52 @@
+"use strict";
+
+import { HttpClientImpl } from "./httpClient";
+
+declare var global: any;
+
+/**
+ * Makes requests using the fetch API
+ */
+export class SPRequestExecutorClient implements HttpClientImpl {
+    public fetch(url: string, options: any): Promise<Response> {
+        let addinWebUrl = url.substring(0, url.indexOf("/_api")),
+            executor = new SP.RequestExecutor(addinWebUrl),
+            headers: { [key: string]: string; } = {},
+            iterator = options.headers.entries(),
+            temp = iterator.next();
+
+        while (!temp.done) {
+            headers[temp.value[0]] = temp.value[1];
+            temp = iterator.next();
+        }
+
+        return new Promise((resolve, reject) => {
+            executor.executeAsync(
+            {
+                error: function (error: SP.ResponseInfo) {
+                    reject(error);
+                },
+                headers: headers,
+                method: options.method,
+                success: (response: SP.ResponseInfo) => {
+                    let responseHeaders = new Headers();
+                    for (let h in response.headers) {
+                        if (response.headers[h]) {
+                            responseHeaders.append(h, response.headers[h]);
+                        }
+                    }
+
+                    let result = new Response(<any>response.body, {
+                        headers: responseHeaders,
+                        status: response.statusCode,
+                        statusText: response.statusText,
+                    });
+
+                    resolve(result);
+                },
+                url: url,
+            }
+        );
+        });
+    }
+}

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -35,6 +35,7 @@ export class SPRequestExecutorClient implements HttpClientImpl {
         return new Promise((resolve, reject) => {
             executor.executeAsync(
                 {
+                    body: options.body,
                     error: (error: SP.ResponseInfo) => {
                         reject(this.convertToResponse(error));
                     },

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -22,31 +22,33 @@ export class SPRequestExecutorClient implements HttpClientImpl {
 
         return new Promise((resolve, reject) => {
             executor.executeAsync(
-            {
-                error: function (error: SP.ResponseInfo) {
-                    reject(error);
-                },
-                headers: headers,
-                method: options.method,
-                success: (response: SP.ResponseInfo) => {
-                    let responseHeaders = new Headers();
-                    for (let h in response.headers) {
-                        if (response.headers[h]) {
-                            responseHeaders.append(h, response.headers[h]);
-                        }
-                    }
-
-                    let result = new Response(<any>response.body, {
-                        headers: responseHeaders,
-                        status: response.statusCode,
-                        statusText: response.statusText,
-                    });
-
-                    resolve(result);
-                },
-                url: url,
-            }
-        );
+                {
+                    error: (error: SP.ResponseInfo) => {
+                        reject(this.convertToResponse(error));
+                    },
+                    headers: headers,
+                    method: options.method,
+                    success: (response: SP.ResponseInfo) => {
+                        resolve(this.convertToResponse(response));
+                    },
+                    url: url,
+                }
+            );
         });
     }
+
+    private convertToResponse = (spResponse: SP.ResponseInfo): Response => {
+        let responseHeaders = new Headers();
+        for (let h in spResponse.headers) {
+            if (spResponse.headers[h]) {
+                responseHeaders.append(h, spResponse.headers[h]);
+            }
+        }
+
+        return new Response(<any>spResponse.body, {
+            headers: responseHeaders,
+            status: spResponse.statusCode,
+            statusText: spResponse.statusText,
+        });
+    };
 }

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -8,38 +8,16 @@ declare var global: any;
  * Makes requests using the fetch API
  */
 export class SPRequestExecutorClient implements HttpClientImpl {
+
+    /**
+     * One promise for loading the SP.RequestExecutor script file.
+     */
+    private static loadingPromise: Promise<void>;
+
     public fetch(url: string, options: any): Promise<Response> {
-        let addinWebUrl = url.substring(0, url.indexOf("/_api")),
-            executor = new SP.RequestExecutor(addinWebUrl),
-            headers: { [key: string]: string; } = {},
-            iterator,
-            temp;
-
-        if (options.headers && options.headers instanceof Headers) {
-            iterator = options.headers.entries();
-            temp = iterator.next();
-            while (!temp.done) {
-                headers[temp.value[0]] = temp.value[1];
-                temp = iterator.next();
-            }
-        } else {
-            headers = options.headers;
-        }
-
-        return new Promise((resolve, reject) => {
-            executor.executeAsync(
-                {
-                    error: (error: SP.ResponseInfo) => {
-                        reject(this.convertToResponse(error));
-                    },
-                    headers: headers,
-                    method: options.method,
-                    success: (response: SP.ResponseInfo) => {
-                        resolve(this.convertToResponse(response));
-                    },
-                    url: url,
-                }
-            );
+        let addinWebUrl = url.substring(0, url.indexOf("/_api"));
+        return this.ensureSPRequestExecutor(addinWebUrl).then(() => {
+            return this.executeRequest(addinWebUrl, url, options);
         });
     }
 
@@ -55,6 +33,65 @@ export class SPRequestExecutorClient implements HttpClientImpl {
             headers: responseHeaders,
             status: spResponse.statusCode,
             statusText: spResponse.statusText,
+        });
+    };
+
+    private ensureSPRequestExecutor = (addinWebUrl: string): Promise<void> => {
+        if (!SPRequestExecutorClient.loadingPromise) {
+            // Initialize new promise for loading the script
+            SPRequestExecutorClient.loadingPromise = new Promise<void>((resolve, reject) => {
+                if (typeof SP === "undefined" || typeof SP.RequestExecutor === "undefined") {
+                    // load the SP.RequestExecutor from the addin web.
+                    let head = document.getElementsByTagName("head")[0],
+                        script = document.createElement("script");
+                    script.type = "text/javascript";
+                    script.onload = () => {
+                        resolve();
+                    };
+                    script.src = addinWebUrl + "/_layouts/15/SP.RequestExecutor.js";
+                    head.appendChild(script);
+                } else {
+                    // SP.RequestExecutor already loaded
+                    resolve();
+                }
+            });
+        }
+
+        return SPRequestExecutorClient.loadingPromise;
+
+    };
+
+    private executeRequest = (addinWebUrl: string, url: string, options: any): Promise<Response> => {
+        return new Promise((resolve, reject) => {
+            let executor = new SP.RequestExecutor(addinWebUrl),
+                headers: { [key: string]: string; } = {},
+                iterator,
+                temp;
+
+            if (options.headers && options.headers instanceof Headers) {
+                iterator = options.headers.entries();
+                temp = iterator.next();
+                while (!temp.done) {
+                    headers[temp.value[0]] = temp.value[1];
+                    temp = iterator.next();
+                }
+            } else {
+                headers = options.headers;
+            }
+
+            executor.executeAsync(
+                {
+                    error: (error: SP.ResponseInfo) => {
+                        reject(this.convertToResponse(error));
+                    },
+                    headers: headers,
+                    method: options.method,
+                    success: (response: SP.ResponseInfo) => {
+                        resolve(this.convertToResponse(response));
+                    },
+                    url: url,
+                }
+            );
         });
     };
 }

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -12,12 +12,15 @@ export class SPRequestExecutorClient implements HttpClientImpl {
         let addinWebUrl = url.substring(0, url.indexOf("/_api")),
             executor = new SP.RequestExecutor(addinWebUrl),
             headers: { [key: string]: string; } = {},
-            iterator = options.headers.entries(),
+            iterator,
             temp = iterator.next();
 
-        while (!temp.done) {
-            headers[temp.value[0]] = temp.value[1];
-            temp = iterator.next();
+        if (options.headers) {
+            iterator = options.headers.entries();
+            while (!temp.done) {
+                headers[temp.value[0]] = temp.value[1];
+                temp = iterator.next();
+            }
         }
 
         return new Promise((resolve, reject) => {

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -13,10 +13,11 @@ export class SPRequestExecutorClient implements HttpClientImpl {
             executor = new SP.RequestExecutor(addinWebUrl),
             headers: { [key: string]: string; } = {},
             iterator,
-            temp = iterator.next();
+            temp;
 
         if (options.headers) {
             iterator = options.headers.entries();
+            temp = iterator.next();
             while (!temp.done) {
                 headers[temp.value[0]] = temp.value[1];
                 temp = iterator.next();

--- a/src/net/SPRequestExecutorClient.ts
+++ b/src/net/SPRequestExecutorClient.ts
@@ -15,13 +15,15 @@ export class SPRequestExecutorClient implements HttpClientImpl {
             iterator,
             temp;
 
-        if (options.headers) {
+        if (options.headers && options.headers instanceof Headers) {
             iterator = options.headers.entries();
             temp = iterator.next();
             while (!temp.done) {
                 headers[temp.value[0]] = temp.value[1];
                 temp = iterator.next();
             }
+        } else {
+            headers = options.headers;
         }
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

Support for CORS calls using the SP.RequestExecutor object, see Yammer discussion (https://www.yammer.com/itpronetwork/#/Threads/show?threadId=718329691).

Use pnp.setup( {  useSPRequestExecutor: true } ) to enable CORS, then use pnp.sp.crossDomainWeb to make the calls.

Include the /_layouts/15/SP.RequestExecutor.js in your page to have the SP.RequestExecutor available.
