### PR TITLE
Adding support for caching and batching to the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,20 @@ Add the package from bower
 We have active [Yammer](http://aka.ms/OfficeDevPnPSIGJavaScriptYammer) and [Gitter](https://gitter.im/OfficeDev/PnP-JS-Core) communities dedicated to this library, please join the conversation to ask questions. If you find an issue with the library, please [report it](https://github.com/OfficeDev/PnP-JS-Core/issues).
 
 
-
 ### Wiki ###
 
 Please see [the wiki](https://github.com/OfficeDev/PnP-JS-Core/wiki) for tips on getting started, configuring your development environment, and using the library.
 
 
 ### Authors ###
-This project's contributors include Microsoft and [community contributors](AUTHORS). Work is done as as open source community project. 
+This project's contributors include Microsoft and [community contributors](AUTHORS). Work is done as as open source community project.
 
 
-###"Sharing is Caring"###
+### Code of Conduct ###
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+
+### "Sharing is Caring" ###
 ----------
 ### Disclaimer ###
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 
 ### "Sharing is Caring" ###
-----------
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ### Disclaimer ###
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/server-root/scratchpad.js
+++ b/server-root/scratchpad.js
@@ -26,15 +26,17 @@ require(["pnp"], function (pnp) {
         });
     }
 
-    pnp.setup({
-        headers: {
-            "Accept": "application/json; odata=verbose"
-        }
-    });
+    // pnp.setup({
+    //     headers: {
+    //         "Accept": "application/json; odata=verbose"
+    //     }
+    // });
 
-    pnp.sp.web.lists.getByTitle("Config3").items.add({ Title: "Another Item" }).then(function (result) {
-        show(result.data);
-    });
+    // pnp.thing(show);
+
+    // pnp.sp.web.lists.getByTitle("Config3").items.add({ Title: "Another Item" }).then(function (result) {
+    //     show(result.data);
+    // });
 
     // pnp.sp.web.lists.getByTitle("Config3").items.get().then(show);
 

--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -1,27 +1,76 @@
 import { TypedHash } from "../collections/collections";
 
 export interface LibraryConfiguration {
+
+    /**
+     * Any headers to apply to all requests
+     */
     headers?: TypedHash<string>;
+
+    /**
+     * Allows caching to be global disabled, default: false
+     */
+    globalCacheDisable?: boolean;
+
+    /**
+     * Defines the default store used by the usingCaching method, default: session
+     */
+    defaultCachingStore?: "session" | "local";
+
+    /**
+     * Defines the default timeout in seconds used by the usingCaching method, default 30
+     */
+    defaultCachingTimeoutSeconds?: number;
 }
 
 export class RuntimeConfigImpl {
 
     constructor() {
+        // these are our default values for the library
         this._headers = null;
+        this._defaultCachingStore = "session";
+        this._defaultCachingTimeoutSeconds = 30;
+        this._globalCacheDisable = false;
     }
 
     private _headers: TypedHash<string>;
+    private _defaultCachingStore: "session" | "local";
+    private _defaultCachingTimeoutSeconds: number;
+    private _globalCacheDisable: boolean;
 
     public set(config: LibraryConfiguration): void {
 
-        // add any headers that are supplied
         if (config.hasOwnProperty("headers")) {
             this._headers = config.headers;
+        }
+
+        if (config.hasOwnProperty("globalCacheDisable")) {
+            this._globalCacheDisable = config.globalCacheDisable;
+        }
+
+        if (config.hasOwnProperty("defaultCachingStore")) {
+            this._defaultCachingStore = config.defaultCachingStore;
+        }
+
+        if (config.hasOwnProperty("defaultCachingTimeoutSeconds")) {
+            this._defaultCachingTimeoutSeconds = config.defaultCachingTimeoutSeconds;
         }
     }
 
     public get headers(): TypedHash<string> {
         return this._headers;
+    }
+
+    public get defaultCachingStore(): "session" | "local" {
+        return this._defaultCachingStore;
+    }
+
+    public get defaultCachingTimeoutSeconds(): number {
+        return this._defaultCachingTimeoutSeconds;
+    }
+
+    public get globalCacheDisable(): boolean {
+        return this._globalCacheDisable;
     }
 }
 

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -14,7 +14,6 @@ export interface FetchOptions {
     cache?: string | RequestCache;
 }
 
-
 export class HttpClient {
 
     constructor(private _impl = new FetchClient()) {

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -5,6 +5,16 @@ import { DigestCache } from "./digestCache";
 import { Util } from "../utils/util";
 import { RuntimeConfig } from "../configuration/pnplibconfig";
 
+export interface FetchOptions {
+    method?: string;
+    headers?: HeaderInit | { [index: string]: string };
+    body?: BodyInit;
+    mode?: string | RequestMode;
+    credentials?: string | RequestCredentials;
+    cache?: string | RequestCache;
+}
+
+
 export class HttpClient {
 
     constructor(private _impl = new FetchClient()) {
@@ -13,7 +23,7 @@ export class HttpClient {
 
     private _digestCache: DigestCache;
 
-    public fetch(url: string, options: any = {}): Promise<Response> {
+    public fetch(url: string, options: FetchOptions = {}): Promise<Response> {
 
         let self = this;
 
@@ -60,7 +70,7 @@ export class HttpClient {
         return self.fetchRaw(url, opts);
     }
 
-    public fetchRaw(url: string, options: any = {}): Promise<Response> {
+    public fetchRaw(url: string, options: FetchOptions = {}): Promise<Response> {
 
         let retry = (ctx): void => {
 
@@ -103,18 +113,18 @@ export class HttpClient {
         });
     }
 
-    public get(url: string, options: any = {}): Promise<Response> {
+    public get(url: string, options: FetchOptions = {}): Promise<Response> {
         let opts = Util.extend(options, { method: "GET" });
         return this.fetch(url, opts);
     }
 
-    public post(url: string, options: any = {}): Promise<Response> {
+    public post(url: string, options: FetchOptions = {}): Promise<Response> {
         let opts = Util.extend(options, { method: "POST" });
         return this.fetch(url, opts);
     }
 
     private mergeHeaders(target: Headers, source: any): void {
-       if (typeof source !== "undefined") {
+        if (typeof source !== "undefined") {
             let temp = <any>new Request("", { headers: source });
             temp.headers.forEach((value, name) => {
                 target.append(name, value);

--- a/src/sharepoint/rest/caching.ts
+++ b/src/sharepoint/rest/caching.ts
@@ -1,0 +1,47 @@
+import { ODataParser } from "./odata";
+import { PnPClientStore, PnPClientStorage } from "../../utils/storage";
+import { Util } from "../../utils/util";
+import { RuntimeConfig } from "../../configuration/pnplibconfig";
+
+export interface ICachingOptions {
+    expiration?: Date;
+    storeName?: "session" | "local";
+    key: string;
+}
+
+export class CachingOptions implements ICachingOptions {
+
+    constructor(public key: string) {}
+
+    protected static storage = new PnPClientStorage();
+
+    public expiration = Util.dateAdd(new Date(), "second", RuntimeConfig.defaultCachingTimeoutSeconds);
+
+    public storeName: "session" | "local" = RuntimeConfig.defaultCachingStore;
+
+    public get store(): PnPClientStore {
+        if (this.storeName === "local") {
+            return CachingOptions.storage.local;
+        } else {
+            return CachingOptions.storage.session;
+        }
+    }
+}
+
+export class CachingParserWrapper<T, U> implements ODataParser<T, U> {
+
+    constructor(
+        private _parser: ODataParser<T, U>,
+        private _cacheOptions: CachingOptions) { }
+
+    public parse(response: Response): Promise<U> {
+
+        // add this to the cache based on the options
+        return this._parser.parse(response).then(data => {
+
+            this._cacheOptions.store.put(this._cacheOptions.key, data, this._cacheOptions.expiration);
+
+            return data;
+        });
+    }
+}

--- a/src/sharepoint/rest/lists.ts
+++ b/src/sharepoint/rest/lists.ts
@@ -77,7 +77,8 @@ export class Lists extends QueryableCollection {
     /*tslint:enable */
 
     /**
-     * Ensures that the specified list exists in the collection (note: settings are not updated if the list exists)
+     * Ensures that the specified list exists in the collection (note: settings are not updated if the list exists,
+     * not supported for batching)
      *
      * @param title The new list's title
      * @param description The new list's description
@@ -88,6 +89,10 @@ export class Lists extends QueryableCollection {
     /*tslint:disable max-line-length */
     public ensure(title: string, description = "", template = 100, enableContentTypes = false, additionalSettings: TypedHash<string | number | boolean> = {}): Promise<ListEnsureResult> {
 
+        if (this.hasBatch) {
+            throw new Error("The ensure method is not supported as part of a batch.");
+        }
+
         return new Promise((resolve, reject) => {
 
             let list: List = this.getByTitle(title);
@@ -95,7 +100,7 @@ export class Lists extends QueryableCollection {
             list.get().then((d) => resolve({ created: false, list: list, data: d })).catch(() => {
 
                 this.add(title, description, template, enableContentTypes, additionalSettings).then((r) => {
-                    resolve({ created: true, list: this.getByTitle(title), data: r.data })
+                    resolve({ created: true, list: this.getByTitle(title), data: r.data });
                 });
 
             }).catch((e) => reject(e));

--- a/src/sharepoint/rest/odata.ts
+++ b/src/sharepoint/rest/odata.ts
@@ -1,6 +1,8 @@
 import { QueryableConstructor } from "./queryable";
 import { Util } from "../../utils/util";
 import { Logger } from "../../utils/logging";
+import { HttpClient } from "../../net/httpclient";
+import { RuntimeConfig } from "../../configuration/pnplibconfig";
 
 export interface ODataParser<T, U> {
     parse(r: Response): Promise<U>;
@@ -81,7 +83,7 @@ function getEntityUrl(entity: any): string {
         return entity.__metadata.uri;
     } else if (entity.hasOwnProperty("odata.editLink")) {
         // we are dealign with minimal metadata (default)
-        return Util.combinePaths("_api",  entity["odata.editLink"]);
+        return Util.combinePaths("_api", entity["odata.editLink"]);
     } else {
         // we are likely dealing with nometadata, so don't error but we won't be able to
         // chain off these objects (write something to log?)
@@ -102,4 +104,262 @@ export function ODataEntity<T>(factory: QueryableConstructor<T>): ODataParser<T,
 
 export function ODataEntityArray<T>(factory: QueryableConstructor<T>): ODataParser<T, T[]> {
     return new ODataEntityArrayParserImpl<T>(factory);
+}
+
+/**
+ * Manages a batch of OData operations
+ */
+export class ODataBatch {
+
+    constructor(private _batchId = Util.getGUID()) {
+        this._requests = [];
+        this._batchDepCount = 0;
+    }
+
+    private _batchDepCount: number;
+    private _requests: ODataBatchRequestInfo[];
+
+    /**
+     * Adds a request to a batch (not designed for public use)
+     * 
+     * @param url The full url of the request
+     * @param method The http method GET, POST, etc
+     * @param options Any options to include in the request
+     * @param parser The parser that will hadle the results of the request
+     */
+    public add<U>(url: string, method: string, options: any, parser: ODataParser<any, U>): Promise<U> {
+
+        let info = {
+            method: method.toUpperCase(),
+            options: options,
+            parser: parser,
+            reject: null,
+            resolve: null,
+            url: url,
+        };
+
+        let p = new Promise<U>((resolve, reject) => {
+            info.resolve = resolve;
+            info.reject = reject;
+        });
+
+        this._requests.push(info);
+
+        return p;
+    }
+
+    public incrementBatchDep() {
+        this._batchDepCount++;
+    }
+
+    public decrementBatchDep() {
+        this._batchDepCount--;
+    }
+
+    /**
+     * Execute the current batch and resolve the associated promises
+     */
+    public execute(): void {
+        if (this._batchDepCount > 0) {
+            setTimeout(() => this.execute(), 100);
+        } else {
+            this.executeImpl();
+        }
+    }
+
+    private executeImpl(): void {
+
+        // if we don't have any requests, don't bother sending anything
+        // this could be due to caching further upstream, or just an empty batch 
+        if (this._requests.length < 1) {
+            return;
+        }
+
+        // build all the requests, send them, pipe results in order to parsers
+        let batchBody: string[] = [];
+
+        let currentChangeSetId = "";
+
+        this._requests.forEach((reqInfo, index) => {
+
+            if (reqInfo.method === "GET") {
+
+                if (currentChangeSetId.length > 0) {
+                    // end an existing change set
+                    batchBody.push(`--changeset_${currentChangeSetId}--\n\n`);
+                    currentChangeSetId = "";
+                }
+
+                batchBody.push(`--batch_${this._batchId}\n`);
+
+            } else {
+
+                if (currentChangeSetId.length < 1) {
+                    // start new change set
+                    currentChangeSetId = Util.getGUID();
+                    batchBody.push(`--batch_${this._batchId}\n`);
+                    batchBody.push(`Content-Type: multipart/mixed; boundary="changeset_${currentChangeSetId}"\n\n`);
+                }
+
+                batchBody.push(`--changeset_${currentChangeSetId}\n`);
+            }
+
+            // common batch part prefix
+            batchBody.push(`Content-Type: application/http\n`);
+            batchBody.push(`Content-Transfer-Encoding: binary\n\n`);
+
+            let headers = {
+                "Accept": "application/json;",
+            };
+
+            if (reqInfo.method !== "GET") {
+
+                let method = reqInfo.method;
+
+                if (reqInfo.options && reqInfo.options.headers && reqInfo.options.headers["X-HTTP-Method"] !== typeof undefined) {
+                    method = reqInfo.options.headers["X-HTTP-Method"];
+                    delete reqInfo.options.headers["X-HTTP-Method"];
+                }
+
+                batchBody.push(`${method} ${reqInfo.url} HTTP/1.1\n`);
+
+                headers = Util.extend(headers, { "Content-Type": "application/json;odata=verbose;charset=utf-8" });
+
+            } else {
+                batchBody.push(`${reqInfo.method} ${reqInfo.url} HTTP/1.1\n`);
+            }
+
+            if (typeof RuntimeConfig.headers !== "undefined") {
+                headers = Util.extend(headers, RuntimeConfig.headers);
+            }
+
+            if (reqInfo.options && reqInfo.options.headers) {
+                headers = Util.extend(headers, reqInfo.options.headers);
+            }
+
+            for (let name in headers) {
+                if (headers.hasOwnProperty(name)) {
+                    batchBody.push(`${name}: ${headers[name]}\n`);
+                }
+            }
+
+            batchBody.push("\n");
+
+            if (reqInfo.options.body) {
+                batchBody.push(`${reqInfo.options.body}\n\n`);
+            }
+        });
+
+        if (currentChangeSetId.length > 0) {
+            // Close the changeset
+            batchBody.push(`--changeset_${currentChangeSetId}--\n\n`);
+            currentChangeSetId = "";
+        }
+
+        batchBody.push(`--batch_${this._batchId}--\n`);
+
+        let batchOptions = {
+            body: batchBody.join(""),
+            headers: {
+                "Content-Type": `multipart/mixed; boundary=batch_${this._batchId}`,
+            },
+        };
+
+        let client = new HttpClient();
+        client.post(Util.makeUrlAbsolute("/_api/$batch"), batchOptions)
+            .then(r => r.text())
+            .then(this._parseResponse)
+            .then(responses => {
+                if (responses.length !== this._requests.length) {
+                    // this is unfortunate
+                    throw new Error("Could not properly parse responses to match requests in batch.");
+                }
+
+                for (let i = 0; i < responses.length; i++) {
+                    let request = this._requests[i];
+                    let response = responses[i];
+
+                    if (!response.ok) {
+                        request.reject(new Error(response.statusText));
+                    }
+
+                    request.parser.parse(response).then(request.resolve).catch(request.reject);
+                }
+            });
+    }
+
+    /**
+     * Parses the response from a batch request into an array of Response instances
+     * 
+     * @param body Text body of the response from the batch request
+     */
+    private _parseResponse(body: string): Promise<Response[]> {
+        return new Promise((resolve, reject) => {
+            let responses = [];
+            let header = "--batchresponse_";
+            // Ex. "HTTP/1.1 500 Internal Server Error"
+            let statusRegExp = new RegExp("^HTTP/[0-9.]+ +([0-9]+) +(.*)", "i");
+            let lines = body.split("\n");
+            let state = "batch";
+            let status;
+            let statusText;
+            for (let i = 0; i < lines.length; ++i) {
+                let line = lines[i];
+                switch (state) {
+                    case "batch":
+                        if (line.substr(0, header.length) === header) {
+                            state = "batchHeaders";
+                        } else {
+                            if (line.trim() !== "") {
+                                throw new Error("Invalid response, line " + i);
+                            }
+                        }
+                        break;
+                    case "batchHeaders":
+                        if (line.trim() === "") {
+                            state = "status";
+                        }
+                        break;
+                    case "status":
+                        let parts = statusRegExp.exec(line);
+                        if (parts.length !== 3) {
+                            throw new Error("Invalid status, line " + i);
+                        }
+                        status = parseInt(parts[1], 10);
+                        statusText = parts[2];
+                        state = "statusHeaders";
+                        break;
+                    case "statusHeaders":
+                        if (line.trim() === "") {
+                            state = "body";
+                        }
+                        break;
+                    case "body":
+                        let response = void 0;
+                        if (status === 204) {
+                            // https://github.com/whatwg/fetch/issues/178
+                            response = new Response();
+                        } else {
+                            response = new Response(line, { status: status, statusText: statusText });
+                        }
+                        responses.push(response);
+                        state = "batch";
+                        break;
+                }
+            }
+            if (state !== "status") {
+                reject(new Error("Unexpected end of input"));
+            }
+            resolve(responses);
+        });
+    }
+}
+
+interface ODataBatchRequestInfo {
+    url: string;
+    method: string;
+    options: any;
+    parser: ODataParser<any, any>;
+    resolve: (d: any) => void;
+    reject: (error: any) => void;
 }

--- a/src/sharepoint/rest/odata.ts
+++ b/src/sharepoint/rest/odata.ts
@@ -258,11 +258,12 @@ export class ODataBatch {
 
         batchBody.push(`--batch_${this._batchId}--\n`);
 
+        let batchHeaders = new Headers();
+        batchHeaders.append("Content-Type", `multipart/mixed; boundary=batch_${this._batchId}`);
+
         let batchOptions = {
-            body: batchBody.join(""),
-            headers: {
-                "Content-Type": `multipart/mixed; boundary=batch_${this._batchId}`,
-            },
+            "body": batchBody.join(""),
+            "headers": batchHeaders,
         };
 
         let client = new HttpClient();

--- a/src/sharepoint/rest/queryable.ts
+++ b/src/sharepoint/rest/queryable.ts
@@ -2,7 +2,7 @@
 
 import { Util } from "../../utils/util";
 import { Dictionary } from "../../collections/collections";
-import { HttpClient } from "../../net/HttpClient";
+import { FetchOptions, HttpClient } from "../../net/HttpClient";
 import { ODataParser, ODataDefaultParser, ODataBatch } from "./odata";
 import { ICachingOptions, CachingParserWrapper, CachingOptions } from "./caching";
 import { RuntimeConfig } from "../../configuration/pnplibconfig";
@@ -211,19 +211,19 @@ export class Queryable {
      * Executes the currently built request
      *
      */
-    public get(parser: ODataParser<any, any> = new ODataDefaultParser(), getOptions: any = {}): Promise<any> {
+    public get(parser: ODataParser<any, any> = new ODataDefaultParser(), getOptions: FetchOptions = {}): Promise<any> {
         return this.getImpl(getOptions, parser);
     }
 
-    public getAs<T, U>(parser: ODataParser<T, U> = new ODataDefaultParser(), getOptions: any = {}): Promise<U> {
+    public getAs<T, U>(parser: ODataParser<T, U> = new ODataDefaultParser(), getOptions: FetchOptions = {}): Promise<U> {
         return this.getImpl(getOptions, parser);
     }
 
-    protected post(postOptions: any = {}, parser: ODataParser<any, any> = new ODataDefaultParser()): Promise<any> {
+    protected post(postOptions: FetchOptions = {}, parser: ODataParser<any, any> = new ODataDefaultParser()): Promise<any> {
         return this.postImpl(postOptions, parser);
     }
 
-    protected postAs<T, U>(postOptions: any = {}, parser: ODataParser<T, U> = new ODataDefaultParser()): Promise<U> {
+    protected postAs<T, U>(postOptions: FetchOptions = {}, parser: ODataParser<T, U> = new ODataDefaultParser()): Promise<U> {
         return this.postImpl(postOptions, parser);
     }
 
@@ -245,7 +245,7 @@ export class Queryable {
         return parent;
     }
 
-    private getImpl<U>(getOptions: any = {}, parser: ODataParser<any, U>): Promise<U> {
+    private getImpl<U>(getOptions: FetchOptions = {}, parser: ODataParser<any, U>): Promise<U> {
 
         if (this._useCaching) {
             let options = new CachingOptions(this.toUrlAndQuery().toLowerCase());
@@ -282,7 +282,7 @@ export class Queryable {
         }
     }
 
-    private postImpl<U>(postOptions: any, parser: ODataParser<any, U>): Promise<U> {
+    private postImpl<U>(postOptions: FetchOptions, parser: ODataParser<any, U>): Promise<U> {
 
         if (this._batch === null) {
 

--- a/src/sharepoint/rest/queryable.ts
+++ b/src/sharepoint/rest/queryable.ts
@@ -3,7 +3,9 @@
 import { Util } from "../../utils/util";
 import { Dictionary } from "../../collections/collections";
 import { HttpClient } from "../../net/HttpClient";
-import { ODataParser, ODataDefaultParser } from "./odata";
+import { ODataParser, ODataDefaultParser, ODataBatch } from "./odata";
+import { ICachingOptions, CachingParserWrapper, CachingOptions } from "./caching";
+import { RuntimeConfig } from "../../configuration/pnplibconfig";
 
 declare var _spPageContextInfo: any;
 
@@ -27,6 +29,7 @@ export class Queryable {
     constructor(baseUrl: string | Queryable, path?: string) {
 
         this._query = new Dictionary<string>();
+        this._batch = null;
 
         if (typeof baseUrl === "string") {
             // we need to do some extra parsing to get the parent url correct if we are
@@ -49,6 +52,10 @@ export class Queryable {
         } else {
             let q = baseUrl as Queryable;
             this._parentUrl = q._url;
+            // only copy batch if we don't already have one
+            if (!this.hasBatch && q.hasBatch) {
+                this._batch = q._batch;
+            }
             let target = q._query.get("@target");
             if (target !== null) {
                 this._query.add("@target", target);
@@ -63,6 +70,11 @@ export class Queryable {
     protected _query: Dictionary<string>;
 
     /**
+     * Tracks the batch of which this query may be part
+     */
+    private _batch: ODataBatch;
+
+    /**
      * Tracks the url as it is built
      */
     private _url: string;
@@ -71,6 +83,16 @@ export class Queryable {
      * Stores the parent url used to create this instance, for recursing back up the tree if needed
      */
     private _parentUrl: string;
+
+    /**
+     * Explicitly tracks if we are using caching for this request
+     */
+    private _useCaching: boolean;
+
+    /**
+     * Any options that were supplied when caching was enabled
+     */
+    private _cachingOptions: ICachingOptions;
 
     /**
      * Directly concatonates the supplied string to the current url, not normalizing "/" chars
@@ -91,6 +113,32 @@ export class Queryable {
     }
 
     /**
+     * Blocks a batch call from occuring, MUST be cleared with clearBatchDependency before a request will execute
+     */
+    protected addBatchDependency() {
+        if (this._batch !== null) {
+            this._batch.incrementBatchDep();
+        }
+    }
+
+    /**
+     * Clears a batch request dependency
+     */
+    protected clearBatchDependency() {
+        if (this._batch !== null) {
+            this._batch.decrementBatchDep();
+        }
+    }
+
+    /**
+     * Indicates if the current query has a batch associated
+     *
+     */
+    protected get hasBatch(): boolean {
+        return this._batch !== null;
+    }
+
+    /**
      * Gets the parent url used when creating this instance
      *
      */
@@ -107,21 +155,42 @@ export class Queryable {
     }
 
     /**
+     * Adds this query to the supplied batch
+     * 
+     * @example
+     * let b = pnp.sp.createBatch(); 
+     * pnp.sp.web.addToBatch(b).get().then(...);
+     */
+    public inBatch(batch: ODataBatch): this {
+        if (this._batch !== null) {
+            // TODO: what do we want to do?
+            throw new Error("This query is already part of a batch.");
+        }
+
+        this._batch = batch;
+
+        return this;
+    }
+
+    /**
+     * Enables caching for this request
+     * 
+     * @param options Defines the options used when caching this request
+     */
+    public usingCaching(options?: ICachingOptions): this {
+        if (!RuntimeConfig.globalCacheDisable) {
+            this._useCaching = true;
+            this._cachingOptions = options;
+        }
+        return this;
+    }
+
+    /**
      * Gets the currentl url, made server relative or absolute based on the availability of the _spPageContextInfo object
      *
      */
     public toUrl(): string {
-        if (!Util.isUrlAbsolute(this._url)) {
-            if (typeof _spPageContextInfo !== "undefined") {
-                if (_spPageContextInfo.hasOwnProperty("webAbsoluteUrl")) {
-                    return Util.combinePaths(_spPageContextInfo.webAbsoluteUrl, this._url);
-                } else if (_spPageContextInfo.hasOwnProperty("webServerRelativeUrl")) {
-                    return Util.combinePaths(_spPageContextInfo.webServerRelativeUrl, this._url);
-                }
-            }
-        }
-
-        return this._url;
+        return Util.makeUrlAbsolute(this._url);
     }
 
     /**
@@ -142,12 +211,12 @@ export class Queryable {
      * Executes the currently built request
      *
      */
-    public get(parser: ODataParser<any, any> = new ODataDefaultParser()): Promise<any> {
-        return this.getImpl(parser);
+    public get(parser: ODataParser<any, any> = new ODataDefaultParser(), getOptions: any = {}): Promise<any> {
+        return this.getImpl(getOptions, parser);
     }
 
-    public getAs<T, U>(parser: ODataParser<T, U> = new ODataDefaultParser()): Promise<U> {
-        return this.getImpl(parser);
+    public getAs<T, U>(parser: ODataParser<T, U> = new ODataDefaultParser(), getOptions: any = {}): Promise<U> {
+        return this.getImpl(getOptions, parser);
     }
 
     protected post(postOptions: any = {}, parser: ODataParser<any, any> = new ODataDefaultParser()): Promise<any> {
@@ -176,42 +245,73 @@ export class Queryable {
         return parent;
     }
 
-    private getImpl<U>(parser: ODataParser<any, U>): Promise<U> {
-        let client = new HttpClient();
-        return client.get(this.toUrlAndQuery()).then(function (response) {
+    private getImpl<U>(getOptions: any = {}, parser: ODataParser<any, U>): Promise<U> {
 
-            if (!response.ok) {
-                throw "Error making GET request: " + response.statusText;
+        if (this._useCaching) {
+            let options = new CachingOptions(this.toUrlAndQuery().toLowerCase());
+            if (typeof this._cachingOptions !== "undefined") {
+                options = Util.extend(options, this._cachingOptions);
             }
 
-            return parser.parse(response);
-        });
+            // check if we have the data in cache and if so return a resolved promise
+            let data = options.store.get(options.key);
+            if (data !== null) {
+                return new Promise(resolve => resolve(data));
+            }
+
+            // if we don't then wrap the supplied parser in the caching parser wrapper
+            // and send things on their way
+            parser = new CachingParserWrapper(parser, options);
+        }
+
+        if (this._batch === null) {
+
+            // we are not part of a batch, so proceed as normal
+            let client = new HttpClient();
+            return client.get(this.toUrlAndQuery(), getOptions).then(function (response) {
+
+                if (!response.ok) {
+                    throw "Error making GET request: " + response.statusText;
+                }
+
+                return parser.parse(response);
+            });
+        } else {
+
+            return this._batch.add(this.toUrlAndQuery(), "GET", {}, parser);
+        }
     }
 
     private postImpl<U>(postOptions: any, parser: ODataParser<any, U>): Promise<U> {
 
-        let client = new HttpClient();
+        if (this._batch === null) {
 
-        return client.post(this.toUrlAndQuery(), postOptions).then(function (response) {
+            // we are not part of a batch, so proceed as normal
+            let client = new HttpClient();
 
-            // 200 = OK (delete)
-            // 201 = Created (create)
-            // 204 = No Content (update)
-            if (!response.ok) {
-                throw "Error making POST request: " + response.statusText;
-            }
+            return client.post(this.toUrlAndQuery(), postOptions).then(function (response) {
 
-            if ((response.headers.has("Content-Length") && parseFloat(response.headers.get("Content-Length")) === 0)
-                || response.status === 204) {
+                // 200 = OK (delete)
+                // 201 = Created (create)
+                // 204 = No Content (update)
+                if (!response.ok) {
+                    throw "Error making POST request: " + response.statusText;
+                }
 
-                // in these cases the server has returned no content, so we create an empty object
-                // this was done because the fetch browser methods throw exceptions with no content
-                return new Promise<any>((resolve, reject) => { resolve({}); });
-            }
+                if ((response.headers.has("Content-Length") && parseFloat(response.headers.get("Content-Length")) === 0)
+                    || response.status === 204) {
 
-            // pipe our parsed content
-            return parser.parse(response);
-        });
+                    // in these cases the server has returned no content, so we create an empty object
+                    // this was done because the fetch browser methods throw exceptions with no content
+                    return new Promise<any>((resolve, reject) => { resolve({}); });
+                }
+
+                // pipe our parsed content
+                return parser.parse(response);
+            });
+        } else {
+            return this._batch.add(this.toUrlAndQuery(), "POST", postOptions, parser);
+        }
     }
 }
 

--- a/src/sharepoint/rest/rest.ts
+++ b/src/sharepoint/rest/rest.ts
@@ -6,6 +6,7 @@ import { Web } from "./webs";
 import { Util } from "../../utils/util";
 import { Queryable } from "./queryable";
 import { UserProfileQuery } from "./userprofiles";
+import { ODataBatch } from "./odata";
 
 /**
  * Root of the SharePoint REST module
@@ -55,13 +56,21 @@ export class Rest {
     }
 
     /**
+     * Creates a new batch object for use with the Queryable.addToBatch method
+     * 
+     */
+    public createBatch(): ODataBatch {
+        return new ODataBatch();
+    }
+
+    /**
      * Begins a cross-domain, host site scoped REST request, for use in add-in webs
      *
      * @param addInWebUrl The absolute url of the add-in web
      * @param hostWebUrl The absolute url of the host web
      */
     public crossDomainSite(addInWebUrl: string, hostWebUrl: string): Site {
-        return this._cdImpl<Site>(Site, addInWebUrl, hostWebUrl, "site");
+        return this._cdImpl(Site, addInWebUrl, hostWebUrl, "site");
     }
 
     /**
@@ -71,7 +80,7 @@ export class Rest {
      * @param hostWebUrl The absolute url of the host web
      */
     public crossDomainWeb(addInWebUrl: string, hostWebUrl: string): Web {
-        return this._cdImpl<Web>(Web, addInWebUrl, hostWebUrl, "web");
+        return this._cdImpl(Web, addInWebUrl, hostWebUrl, "web");
     }
 
     /**

--- a/src/sharepoint/rest/userprofiles.ts
+++ b/src/sharepoint/rest/userprofiles.ts
@@ -168,7 +168,7 @@ export class UserProfileQuery extends QueryableInstance {
         return FileUtil.readBlobAsArrayBuffer(profilePicSource).then((buffer) => {
             let request = new UserProfileQuery(this, "setmyprofilepicture");
             return request.post({
-                body: buffer,
+                body: String.fromCharCode.apply(null, new Uint16Array(buffer)),
             });
         });
     }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -236,4 +236,26 @@ export class Util {
     public static isUrlAbsolute(url: string): boolean {
         return /^https?:\/\/|^\/\//i.test(url);
     }
+
+    /**
+     * Attempts to make the supplied relative url absolute based on the _spPageContextInfo object, if available
+     * 
+     * @param url The relative url to make absolute
+     */
+    public static makeUrlAbsolute(url: string): string {
+
+        if (Util.isUrlAbsolute(url)) {
+            return url;
+        }
+
+        if (typeof _spPageContextInfo !== "undefined") {
+            if (_spPageContextInfo.hasOwnProperty("webAbsoluteUrl")) {
+                return Util.combinePaths(_spPageContextInfo.webAbsoluteUrl, url);
+            } else if (_spPageContextInfo.hasOwnProperty("webServerRelativeUrl")) {
+                return Util.combinePaths(_spPageContextInfo.webServerRelativeUrl, url);
+            }
+        } else {
+            return url;
+        }
+    }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -25,7 +25,7 @@
       "trace"
     ],
     "no-construct": true,
-    "no-debugger": true,
+    "no-debugger": false,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | No
| New feature?    | Yes
| New sample?      | No
| Related issues?  | None

#### What's in this Pull Request?

This PR introduces batching and caching functionality to the library. These methods are composable and you can cache the results of batch requests. You can set global defaults for the caching parameters as well as globally disable caching, say for local testing. Also, the cache parameters can be set on a per call basis. The default cache key is the full request URI with query parameters, default storage is session, and the default timeout is 30 seconds.

```
    let b = pnp.sp.createBatch();

    pnp.sp.web.usingCaching().inBatch(b).get().then(...);

    pnp.sp.web.lists.usingCaching({
        expiration: new Date(2016, 6, 21),
        key: "MyGreatUniqueKey",
        storeName: "local",
    }).inBatch(b).get().then(...);

    pnp.sp.web.lists.getByTitle("Config3").items.usingCaching().inBatch(b).get().then(...);

    b.execute();
```
Also included in this PR is the ability on a per request basis to set options which will be piped to the fetch client directly. These options take precedence over any global headers set using the setup method.

```
pnp.sp.web.get(new ODataDefaultParser(), {
    cache: "default",
    headers: {
	"Accept": "application/json; odata=verbose",
    },
}).then(...)
```


