### PR TITLE
get wopi frame url of item

### DIFF
--- a/src/sharepoint/rest/items.ts
+++ b/src/sharepoint/rest/items.ts
@@ -222,10 +222,12 @@ export class Item extends QueryableSecurable {
      *
      * @param action Display mode: 0: view, 1: edit, 2: mobileView, 3: interactivePreview
      */
-    public getWopiFrameUrl(action = 0): Promise<void> {
+    public getWopiFrameUrl(action = 0): Promise<string> {
         let i = new Item(this, "getWOPIFrameUrl(@action)");
         i._query.add("@action", <any>action);
-        return i.post();
+        return i.post().then((data: { GetWOPIFrameUrl: string }) => {
+            return data.GetWOPIFrameUrl;
+        });
     }
 
     /**

--- a/src/sharepoint/rest/items.ts
+++ b/src/sharepoint/rest/items.ts
@@ -217,6 +217,18 @@ export class Item extends QueryableSecurable {
     }
 
     /**
+     * Gets a string representation of the full URL to the WOPI frame. 
+     * If there is no associated WOPI application, or no associated action, an empty string is returned.
+     *
+     * @param action Display mode: 0: view, 1: edit, 2: mobileView, 3: interactivePreview
+     */
+    public getWopiFrameUrl(action = 0): Promise<void> {
+        let i = new Item(this, "getWOPIFrameUrl(@action)");
+        i._query.add("@action", <any>action);
+        return i.post();
+    }
+
+    /**
      * Validates and sets the values of the specified collection of fields for the list item.
      *
      * @param formValues The fields to change and their new values.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

Added new method for getting the WOPI frame url for an item.
See: https://msdn.microsoft.com/en-us/library/office/jj246933.aspx

Usage:
`...items.getById(1).getWopiFrameUrl().then(function(result) { ... });`