### PR TITLE
adding node fetch client to support requests from nodejs -> sharepoin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "bugs": {
     "url": "https://github.com/OfficeDev/PnP-JS-Core/issues"
   },
-  "homepage": "https://github.com/OfficeDev/PnP-JS-Core"
+  "homepage": "https://github.com/OfficeDev/PnP-JS-Core",
+  "browser": {
+    "./build/src/net/nodefetchclient.js": "./build/src/net/nodefetchclientbrowser.js"
+  }
 }

--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -1,5 +1,11 @@
 import { TypedHash } from "../collections/collections";
 
+export interface NodeClientData {
+    clientId: string;
+    clientSecret: string;
+    siteUrl: string;
+}
+
 export interface LibraryConfiguration {
 
     /**
@@ -26,6 +32,11 @@ export interface LibraryConfiguration {
      * If true the SP.RequestExecutor will be used to make the requests, you must include the required external libs
      */
     useSPRequestExecutor?: boolean;
+
+    /**
+     * If set the library will use node-fetch, typically for use with testing but works with any valid client id/secret pair
+     */
+    nodeClientOptions?: NodeClientData;
 }
 
 export class RuntimeConfigImpl {
@@ -43,7 +54,9 @@ export class RuntimeConfigImpl {
     private _defaultCachingStore: "session" | "local";
     private _defaultCachingTimeoutSeconds: number;
     private _globalCacheDisable: boolean;
-    private _useSPRequestExecutor;
+    private _useSPRequestExecutor: boolean;
+    private _useNodeClient: boolean;
+    private _nodeClientData: NodeClientData;
 
     public set(config: LibraryConfiguration): void {
 
@@ -65,7 +78,12 @@ export class RuntimeConfigImpl {
 
         if (config.hasOwnProperty("useSPRequestExecutor")) {
             this._useSPRequestExecutor = config.useSPRequestExecutor;
+        }
 
+        if (config.hasOwnProperty("nodeClientOptions")) {
+            this._useNodeClient = true;
+            this._useSPRequestExecutor = false; // just don't allow this conflict
+            this._nodeClientData = config.nodeClientOptions;
         }
     }
 
@@ -87,6 +105,14 @@ export class RuntimeConfigImpl {
 
     public get useSPRequestExecutor(): boolean {
         return this._useSPRequestExecutor;
+    }
+
+    public get useNodeFetchClient(): boolean {
+        return this._useNodeClient;
+    }
+
+    public get nodeRequestOptions(): NodeClientData {
+        return this._nodeClientData;
     }
 }
 

--- a/src/net/NodeFetchClient.ts
+++ b/src/net/NodeFetchClient.ts
@@ -1,0 +1,143 @@
+"use strict";
+
+declare var global: any;
+declare var require: (path: string) => any;
+let nodeFetch = require("node-fetch");
+let u: any = require("url");
+import { HttpClientImpl } from "./httpclient";
+import { Util } from "../utils/util";
+
+export interface AuthToken {
+    token_type: string;
+    expires_in: string;
+    not_before: string;
+    expires_on: string;
+    resource: string;
+    access_token: string;
+}
+
+/**
+ * Fetch client for use within nodejs, requires you register a client id and secret with app only permissions
+ */
+export class NodeFetchClient implements HttpClientImpl {
+
+    constructor(public siteUrl: string, private _clientId: string, private _clientSecret: string, private _realm = "") {
+
+        // here we "cheat" and set the globals for fetch things when this client is instantiated
+        global.Headers = nodeFetch.Headers;
+        global.Request = nodeFetch.Request;
+        global.Response = nodeFetch.Response;
+    }
+
+    private static SharePointServicePrincipal: string = "00000003-0000-0ff1-ce00-000000000000";
+    private token: AuthToken = null;
+
+    public fetch(url: string, options: any): Promise<Response> {
+
+        if (!Util.isUrlAbsolute(url)) {
+            url = Util.combinePaths(this.siteUrl, url);
+        }
+
+        return this.getAddInOnlyAccessToken().then(token => {
+            options.headers.set("Authorization", `Bearer ${token.access_token}`);
+            return nodeFetch(url, options);
+        });
+    }
+
+    /**
+     * Gets an add-in only authentication token based on the supplied site url, client id and secret
+     */
+    public getAddInOnlyAccessToken(): Promise<AuthToken> {
+
+        if (this.token !== null && new Date() < this.toDate(this.token.expires_on)) {
+            return new Promise<AuthToken>(r => r(this.token));
+        }
+
+        return this.getRealm().then(realm => {
+
+            let resource = this.getFormattedPrincipal(NodeFetchClient.SharePointServicePrincipal, u.parse(this.siteUrl).hostname, realm);
+            let formattedClientId = this.getFormattedPrincipal(this._clientId, "", realm);
+
+            return this.getAuthUrl(realm).then((authUrl: string) => {
+
+                let body = [];
+                body.push("grant_type=client_credentials");
+                body.push(`client_id=${formattedClientId}`);
+                body.push(`client_secret=${this._clientSecret}`);
+                body.push(`resource=${resource}`);
+
+                return nodeFetch(authUrl, {
+                    body: body.join("&"),
+                    headers: {
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    method: "POST",
+                }).then((r: Response) => r.json()).then(tok => {
+                    this.token = tok;
+                    return this.token;
+                });
+            });
+        });
+    }
+
+    private getRealm(): Promise<string> {
+
+        return new Promise(resolve => {
+
+            if (this._realm.length > 0) {
+                resolve(this._realm);
+            }
+
+            let url = Util.combinePaths(this.siteUrl, "vti_bin/client.svc");
+
+            nodeFetch(url, {
+                "method": "POST",
+                "headers": {
+                    "Authorization": "Bearer ",
+                },
+            }).then((r) => {
+
+                let data: string = r.headers.get("www-authenticate");
+                let index = data.indexOf("Bearer realm=\"");
+                this._realm = data.substring(index + 14, index + 50);
+                resolve(this._realm);
+            });
+        });
+    }
+
+    private getAuthUrl(realm: string): Promise<string> {
+
+        let url = `https://accounts.accesscontrol.windows.net/metadata/json/1?realm=${realm}`;
+
+        return nodeFetch(url).then((r: Response) => r.json()).then((json: { endpoints: { protocol: string, location: string }[] }) => {
+
+            for (let i = 0; i < json.endpoints.length; i++) {
+                if (json.endpoints[i].protocol === "OAuth2") {
+                    return json.endpoints[i].location;
+                }
+            }
+
+            console.log(json);
+            throw new Error("Auth URL Endpoint could not be determined from data. Data logged to console.");
+        });
+    }
+
+    private getFormattedPrincipal(principalName, hostName, realm): string {
+        let resource = principalName;
+        if (hostName !== null && hostName !== "") {
+            resource += "/" + hostName;
+        }
+        resource += "@" + realm;
+        return resource;
+    }
+
+    private toDate(epoch: string): Date {
+        let tmp = parseInt(epoch, 10);
+        if (tmp < 10000000000) {
+            tmp *= 1000;
+        }
+        let d = new Date();
+        d.setTime(tmp);
+        return d;
+    }
+}

--- a/src/net/NodeFetchClientBrowser.ts
+++ b/src/net/NodeFetchClientBrowser.ts
@@ -1,0 +1,19 @@
+"use strict";
+
+import { HttpClientImpl } from "./httpclient";
+
+/**
+ * This module is substituted for the NodeFetchClient.ts during the packaging process. This helps to reduce the pnp.js file size by
+ * not including all of the node dependencies
+ */
+export class NodeFetchClient implements HttpClientImpl {
+
+    constructor(public siteUrl: string, private _clientId: string, private _clientSecret: string, private _realm = "") {}
+
+    /**
+     * Always throws an error that NodeFetchClient is not supported for use in the browser
+     */
+    public fetch(url: string, options: any): Promise<Response> {
+        throw new Error("Using NodeFetchClient in the browser is not supported.");
+    }
+}

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,4 +1,7 @@
 "use strict";
+
+declare var global: any;
+
 export class Util {
 
     /**
@@ -248,11 +251,11 @@ export class Util {
             return url;
         }
 
-        if (typeof _spPageContextInfo !== "undefined") {
-            if (_spPageContextInfo.hasOwnProperty("webAbsoluteUrl")) {
-                return Util.combinePaths(_spPageContextInfo.webAbsoluteUrl, url);
-            } else if (_spPageContextInfo.hasOwnProperty("webServerRelativeUrl")) {
-                return Util.combinePaths(_spPageContextInfo.webServerRelativeUrl, url);
+        if (typeof global._spPageContextInfo !== "undefined") {
+            if (global._spPageContextInfo.hasOwnProperty("webAbsoluteUrl")) {
+                return Util.combinePaths(global._spPageContextInfo.webAbsoluteUrl, url);
+            } else if (global._spPageContextInfo.hasOwnProperty("webServerRelativeUrl")) {
+                return Util.combinePaths(global._spPageContextInfo.webServerRelativeUrl, url);
             }
         } else {
             return url;

--- a/tests/configuration/providers/cachingConfigurationProvider.test.ts
+++ b/tests/configuration/providers/cachingConfigurationProvider.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { default as CachingConfigurationProvider } from "../../../src/configuration/providers/cachingConfigurationProvider";
-import  * as Collections  from "../../src/collections/collections";
+import  * as Collections  from "../../../src/collections/collections";
 import * as Configuration from "../../../src/configuration/configuration";
 import {default as MockConfigurationProvider} from "../../mocks/mockConfigurationProvider";
 import MockStorage from "../../mocks/MockStorage";


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | helps enabled scenarios for #40 

#### What's in this Pull Request?

This PR adds a node fetch client for use within nodejs to make requests against SharePoint. This also enables creating tests against SharePoint sites to test functionality. Usage:

1.Register a new add-in using appregnew.aspx and appinv.aspx
2.Use the setup method to configure the client

```
pnp.setup({
    nodeClientOptions: {
        clientId: "{ your client id }",
        clientSecret: "{ your client secret }",
        siteUrl: "{ your site url }",
    },
});
```

3.Make requests as normal using the library

`pnp.sp.web.select("Title").get().then(t => console.log("here!! " + t.Title));`

You can all use the class directly in your projects as well:

```
import { NodeFetchClient } from "./net/nodefetchclient";
import { ODataDefaultParser } from "./sharepoint/rest/odata";

let client = new NodeFetchClient("{ your site url}", "{ your client id }", "{ your client secret }");

// use fetch directly
client.fetch("/relative/url");

// or get an access token and send it along with the request
client.getAddInOnlyAccessToken().then(token => {

    pnp.sp.web.select("Title").get(new ODataDefaultParser(), {
        headers: {
            "Authorization": `Bearer ${token.access_token}`,
        }
    }).then(w => {
        console.log(w.Title);
    });
});
```

