### PR TITLE
Update for gulp-tslint and associated build task to account for updates

### DIFF
--- a/buildtasks/lint.js
+++ b/buildtasks/lint.js
@@ -20,8 +20,12 @@ var gulp = require("gulp"),
 //* LINT
 //******************************************************************************
 
-gulp.task("lint", function() {
+gulp.task("lint", function () {
     return gulp.src(global.TSWorkspace.Files)
-        .pipe(tslint({}))
-        .pipe(tslint.report("verbose"));
+        .pipe(tslint({
+            formatter: "prose"
+        }))
+        .pipe(tslint.report({
+            emitError: false
+        }));
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-spsave": "^2.0.0",
-    "gulp-tslint": "^4.3.2",
+    "gulp-tslint": "^6.0.1",
     "gulp-typedoc": "^2.0.0",
     "gulp-typescript": "^2.11.0",
     "gulp-uglify": "^1.5.3",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | No
| New feature?    | Yes
| New sample?      | No
| Related issues?  | none

#### What's in this Pull Request?
Fixes an old version of the gulp-tslint library. Also updates the build task to account for new format as well as block the second error getting thrown to clean up UI during lint error reporting.
