### PR TITLE
do a package.json browser switcheroo

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "homepage": "https://github.com/OfficeDev/PnP-JS-Core",
   "browser": {
-    "./build/src/net/nodefetchclient.js": "./build/src/net/nodefetchclientbrowser.js"
+    "./build/src/net/nodefetchclient.js": "./build/src/net/nodefetchclientbrowser.js",
+    "./lib/net/nodefetchclient.js": "./lib/net/nodefetchclientbrowser.js"
   }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #185

#### What's in this Pull Request?

The browser file reference in package.json seems to point to /build/ but should point to /lib/ instead.

./build folders aren't available in node_modules