### PR TITLE
updates to fix tests when web tests are enabled and url is made absolute

### DIFF
--- a/tests/sharepoint/rest/contenttypes.test.ts
+++ b/tests/sharepoint/rest/contenttypes.test.ts
@@ -2,6 +2,11 @@
 
 import { expect } from "chai";
 import { ContentTypes, ContentType } from "../../../src/sharepoint/rest/ContentTypes";
+import pnp from "../../../src/pnp";
+import { testSettings } from "../../test-config.test";
+import { toMatchEndRegex } from "../../testutils";
+
+/* tslint:disable max-line-length */
 
 describe("ContentTypes", () => {
     it("Should be an object", () => {
@@ -11,217 +16,179 @@ describe("ContentTypes", () => {
     describe("url", () => {
         it("Should return _api/web/lists/getByTitle('Tasks')/contenttypes", () => {
             let contenttypes = new ContentTypes("_api/web/lists/getByTitle('Tasks')");
-            expect(contenttypes.toUrl()).to.equal("_api/web/lists/getByTitle('Tasks')/contenttypes");
+            expect(contenttypes.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/contenttypes"));
         });
     });
     describe("getById", () => {
         it("Should return _api/web/lists/getByTitle('Tasks')/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')", () => {
             let contenttypes = new ContentTypes("_api/web/lists/getByTitle('Tasks')");
-            let ct = contenttypes.getById("0x0101000BB1B729DCB7414A9344ED650D3C05B3");
-            expect(ct.toUrl()).to.equal("_api/web/lists/getByTitle('Tasks')/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')");
+            let ct = contenttypes.getById("0x0101000BB1B729DCB7414A9344ED650D3C05B3").toUrl();
+            expect(ct).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')"));
         });
     });
-    describe("ContentType", () => {
-        let contentType: ContentType;
 
-        beforeEach(() => {
-            contentType = new ContentType("_api/web", "contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')");
-        });
+    if (testSettings.enableWebTests) {
 
-        it("Should be an object", () => {
-            expect(contentType).to.be.a("object");
-        });
-
-        describe("descriptionResource", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/descriptionResource", () => {
-                expect(contentType.descriptionResource.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/descriptionResource"
-                    );
+        describe("getById", () => {
+            it("Should return the item content type", () => {
+                return expect(pnp.sp.web.contentTypes.getById("0x01").get()).to.eventually.be.fulfilled;
             });
         });
+    }
+});
 
-        describe("fieldLinks", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fieldLinks", () => {
-                expect(contentType.fieldLinks.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fieldLinks"
-                    );
-            });
+describe("ContentType", () => {
+    let contentType: ContentType;
+
+    beforeEach(() => {
+        contentType = new ContentType("_api/web", "contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')");
+    });
+
+    it("Should be an object", () => {
+        expect(contentType).to.be.an("object");
+    });
+
+    describe("descriptionResource", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/descriptionResource", () => {
+            expect(contentType.descriptionResource.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/descriptionResource"));
         });
+    });
 
-        describe("fields", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fields", () => {
-                expect(contentType.fields.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fields"
-                    );
-            });
+    describe("fieldLinks", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fieldLinks", () => {
+            expect(contentType.fieldLinks.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fieldLinks"));
         });
+    });
 
-        describe("nameResource", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/nameResource", () => {
-                expect(contentType.nameResource.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/nameResource"
-                    );
-            });
+    describe("fields", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fields", () => {
+            expect(contentType.fields.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/fields"));
         });
+    });
 
-        describe("parent", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/parent", () => {
-                expect(contentType.parent.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/parent"
-                    );
-            });
+    describe("nameResource", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/nameResource", () => {
+            expect(contentType.nameResource.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/nameResource"));
         });
+    });
 
-        describe("description", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/description", () => {
-                expect(contentType.description.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/description"
-                    );
-            });
+    describe("parent", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/parent", () => {
+            expect(contentType.parent.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/parent"));
         });
+    });
 
-        describe("workflowAssociations", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/workflowAssociations", () => {
-                expect(contentType.workflowAssociations.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/workflowAssociations"
-                    );
-            });
+    describe("description", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/description", () => {
+            expect(contentType.description.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/description"));
         });
+    });
 
-        describe("displayFormTemplateName", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormTemplateName", () => {
-                expect(contentType.displayFormTemplateName.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormTemplateName"
-                    );
-            });
+    describe("workflowAssociations", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/workflowAssociations", () => {
+            expect(contentType.workflowAssociations.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/workflowAssociations"));
         });
+    });
 
-        describe("displayFormUrl", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormUrl", () => {
-                expect(contentType.displayFormUrl.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormUrl"
-                    );
-            });
+    describe("displayFormTemplateName", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormTemplateName", () => {
+            expect(contentType.displayFormTemplateName.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormTemplateName"));
         });
+    });
 
-        describe("documentTemplate", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplate", () => {
-                expect(contentType.documentTemplate.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplate"
-                    );
-            });
+    describe("displayFormUrl", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormUrl", () => {
+            expect(contentType.displayFormUrl.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/displayFormUrl"));
         });
+    });
 
-        describe("documentTemplateUrl", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplateUrl", () => {
-                expect(contentType.documentTemplateUrl.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplateUrl"
-                    );
-            });
+    describe("documentTemplate", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplate", () => {
+            expect(contentType.documentTemplate.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplate"));
         });
+    });
 
-        describe("editFormTemplateName", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormTemplateName", () => {
-                expect(contentType.editFormTemplateName.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormTemplateName"
-                    );
-            });
+    describe("documentTemplateUrl", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplateUrl", () => {
+            expect(contentType.documentTemplateUrl.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/documentTemplateUrl"));
         });
+    });
 
-        describe("editFormUrl", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormUrl", () => {
-                expect(contentType.editFormUrl.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormUrl"
-                    );
-            });
+    describe("editFormTemplateName", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormTemplateName", () => {
+            expect(contentType.editFormTemplateName.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormTemplateName"));
         });
+    });
 
-        describe("group", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/group", () => {
-                expect(contentType.group.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/group"
-                    );
-            });
+    describe("editFormUrl", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormUrl", () => {
+            expect(contentType.editFormUrl.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/editFormUrl"));
         });
+    });
 
-        describe("hidden", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/hidden", () => {
-                expect(contentType.hidden.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/hidden"
-                    );
-            });
+    describe("group", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/group", () => {
+            expect(contentType.group.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/group"));
         });
+    });
 
-        describe("jsLink", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/jsLink", () => {
-                expect(contentType.jsLink.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/jsLink"
-                    );
-            });
+    describe("hidden", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/hidden", () => {
+            expect(contentType.hidden.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/hidden"));
         });
+    });
 
-        describe("name", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/name", () => {
-                expect(contentType.name.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/name"
-                    );
-            });
+    describe("jsLink", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/jsLink", () => {
+            expect(contentType.jsLink.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/jsLink"));
         });
+    });
 
-        describe("newFormTemplateName", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormTemplateName", () => {
-                expect(contentType.newFormTemplateName.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormTemplateName"
-                    );
-            });
+    describe("name", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/name", () => {
+            expect(contentType.name.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/name"));
         });
+    });
 
-        describe("newFormUrl", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormUrl", () => {
-                expect(contentType.newFormUrl.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormUrl"
-                    );
-            });
+    describe("newFormTemplateName", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormTemplateName", () => {
+            expect(contentType.newFormTemplateName.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormTemplateName"));
         });
+    });
 
-        describe("readOnly", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/readOnly", () => {
-                expect(contentType.readOnly.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/readOnly"
-                    );
-            });
+    describe("newFormUrl", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormUrl", () => {
+            expect(contentType.newFormUrl.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/newFormUrl"));
         });
+    });
 
-        describe("schemaXml", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/schemaXml", () => {
-                expect(contentType.schemaXml.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/schemaXml"
-                    );
-            });
+    describe("readOnly", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/readOnly", () => {
+            expect(contentType.readOnly.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/readOnly"));
         });
+    });
 
-        describe("scope", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/scope", () => {
-                expect(contentType.scope.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/scope"
-                    );
-            });
+    describe("schemaXml", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/schemaXml", () => {
+            expect(contentType.schemaXml.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/schemaXml"));
         });
+    });
 
-        describe("sealed", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/sealed", () => {
-                expect(contentType.sealed.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/sealed"
-                    );
-            });
+    describe("scope", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/scope", () => {
+            expect(contentType.scope.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/scope"));
         });
+    });
 
-        describe("stringId", () => {
-            it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/stringId", () => {
-                expect(contentType.stringId.toUrl()).to.equal(
-                    "_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/stringId"
-                    );
-            });
+    describe("sealed", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/sealed", () => {
+            expect(contentType.sealed.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/sealed"));
+        });
+    });
+
+    describe("stringId", () => {
+        it("Should return _api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/stringId", () => {
+            expect(contentType.stringId.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes('0x0101000BB1B729DCB7414A9344ED650D3C05B3')/stringId"));
         });
     });
 });

--- a/tests/sharepoint/rest/fields.test.ts
+++ b/tests/sharepoint/rest/fields.test.ts
@@ -3,6 +3,7 @@
 import { Util } from "../../../src/utils/util";
 import { expect } from "chai";
 import { Fields, Field } from "../../../src/sharepoint/rest/fields";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Fields", () => {
 
@@ -20,21 +21,21 @@ describe("Fields", () => {
     describe("url", () => {
         let path: string = Util.combinePaths(basePath, "fields");
         it("Should return " + path, () => {
-            expect(fields.toUrl()).to.equal(path);
+            expect(fields.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("getByTitle", () => {
         let path: string = Util.combinePaths(basePath, "fields/getByTitle('Title')");
         it("Should return " + path, () => {
-            expect(fields.getByTitle("Title").toUrl()).to.equal(path);
+            expect(fields.getByTitle("Title").toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("getById", () => {
         let path: string = Util.combinePaths(basePath, "fields('cc1322c5-376d-4b8a-87cb-1e21330c6df2')");
         it("Should return " + path, () => {
-            expect(fields.getById("cc1322c5-376d-4b8a-87cb-1e21330c6df2").toUrl()).to.equal(path);
+            expect(fields.getById("cc1322c5-376d-4b8a-87cb-1e21330c6df2").toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 });
@@ -55,169 +56,169 @@ describe("Field", () => {
     describe("descriptionResource", () => {
         let path: string = Util.combinePaths(basePath, "canBeDeleted");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/canBeDeleted", () => {
-            expect(field.canBeDeleted.toUrl()).to.equal(path);
+            expect(field.canBeDeleted.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("defaultValue", () => {
         let path: string = Util.combinePaths(basePath, "defaultValue");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/defaultValue", () => {
-            expect(field.defaultValue.toUrl()).to.equal(path);
+            expect(field.defaultValue.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("description", () => {
         let path: string = Util.combinePaths(basePath, "description");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/description", () => {
-            expect(field.description.toUrl()).to.equal(path);
+            expect(field.description.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("direction", () => {
         let path: string = Util.combinePaths(basePath, "direction");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/direction", () => {
-            expect(field.direction.toUrl()).to.equal(path);
+            expect(field.direction.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("enforceUniqueValues", () => {
         let path: string = Util.combinePaths(basePath, "enforceUniqueValues");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/enforceUniqueValues", () => {
-            expect(field.enforceUniqueValues.toUrl()).to.equal(path);
+            expect(field.enforceUniqueValues.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("entityPropertyName", () => {
         let path: string = Util.combinePaths(basePath, "entityPropertyName");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/entityPropertyName", () => {
-            expect(field.entityPropertyName.toUrl()).to.equal(path);
+            expect(field.entityPropertyName.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("filterable", () => {
         let path: string = Util.combinePaths(basePath, "filterable");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/filterable", () => {
-            expect(field.filterable.toUrl()).to.equal(path);
+            expect(field.filterable.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("fromBaseType", () => {
         let path: string = Util.combinePaths(basePath, "fromBaseType");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/fromBaseType", () => {
-            expect(field.fromBaseType.toUrl()).to.equal(path);
+            expect(field.fromBaseType.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("group", () => {
         let path: string = Util.combinePaths(basePath, "group");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/group", () => {
-            expect(field.group.toUrl()).to.equal(path);
+            expect(field.group.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("hidden", () => {
         let path: string = Util.combinePaths(basePath, "hidden");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/hidden", () => {
-            expect(field.hidden.toUrl()).to.equal(path);
+            expect(field.hidden.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("id", () => {
         let path: string = Util.combinePaths(basePath, "id");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/id", () => {
-            expect(field.id.toUrl()).to.equal(path);
+            expect(field.id.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("indexed", () => {
         let path: string = Util.combinePaths(basePath, "indexed");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/indexed", () => {
-            expect(field.indexed.toUrl()).to.equal(path);
+            expect(field.indexed.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("internalName", () => {
         let path: string = Util.combinePaths(basePath, "internalName");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/internalName", () => {
-            expect(field.internalName.toUrl()).to.equal(path);
+            expect(field.internalName.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("jsLink", () => {
         let path: string = Util.combinePaths(basePath, "jsLink");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/jsLink", () => {
-            expect(field.jsLink.toUrl()).to.equal(path);
+            expect(field.jsLink.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("readOnlyField", () => {
         let path: string = Util.combinePaths(basePath, "readOnlyField");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/readOnlyField", () => {
-            expect(field.readOnlyField.toUrl()).to.equal(path);
+            expect(field.readOnlyField.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("required", () => {
         let path: string = Util.combinePaths(basePath, "required");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/required", () => {
-            expect(field.required.toUrl()).to.equal(path);
+            expect(field.required.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("schemaXml", () => {
         let path: string = Util.combinePaths(basePath, "schemaXml");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/schemaXml", () => {
-            expect(field.schemaXml.toUrl()).to.equal(path);
+            expect(field.schemaXml.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("scope", () => {
         let path: string = Util.combinePaths(basePath, "scope");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/scope", () => {
-            expect(field.scope.toUrl()).to.equal(path);
+            expect(field.scope.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("sealed", () => {
         let path: string = Util.combinePaths(basePath, "sealed");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/sealed", () => {
-            expect(field.sealed.toUrl()).to.equal(path);
+            expect(field.sealed.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("sortable", () => {
         let path: string = Util.combinePaths(basePath, "sortable");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/sortable", () => {
-            expect(field.sortable.toUrl()).to.equal(path);
+            expect(field.sortable.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("staticName", () => {
         let path: string = Util.combinePaths(basePath, "staticName");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/staticName", () => {
-            expect(field.staticName.toUrl()).to.equal(path);
+            expect(field.staticName.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("title", () => {
         let path: string = Util.combinePaths(basePath, "title");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/title", () => {
-            expect(field.title.toUrl()).to.equal(path);
+            expect(field.title.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("fieldTypeKind", () => {
         let path: string = Util.combinePaths(basePath, "fieldTypeKind");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/fieldTypeKind", () => {
-            expect(field.fieldTypeKind.toUrl()).to.equal(path);
+            expect(field.fieldTypeKind.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("typeAsString", () => {
         let path: string = Util.combinePaths(basePath, "typeAsString");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/typeAsString", () => {
-            expect(field.typeAsString.toUrl()).to.equal(path);
+            expect(field.typeAsString.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("typeDisplayName", () => {
         let path: string = Util.combinePaths(basePath, "typeDisplayName");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/typeDisplayName", () => {
-            expect(field.typeDisplayName.toUrl()).to.equal(path);
+            expect(field.typeDisplayName.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("typeShortDescription", () => {
         let path: string = Util.combinePaths(basePath, "typeShortDescription");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/typeShortDescription", () => {
-            expect(field.typeShortDescription.toUrl()).to.equal(path);
+            expect(field.typeShortDescription.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("validationFormula", () => {
         let path: string = Util.combinePaths(basePath, "validationFormula");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/validationFormula", () => {
-            expect(field.validationFormula.toUrl()).to.equal(path);
+            expect(field.validationFormula.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("validationMessage", () => {
         let path: string = Util.combinePaths(basePath, "validationMessage");
         it("Should return _api/web/lists/getByTitle('Tasks')/fields/getByTitle('Title')/validationMessage", () => {
-            expect(field.validationMessage.toUrl()).to.equal(path);
+            expect(field.validationMessage.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 });

--- a/tests/sharepoint/rest/files.test.ts
+++ b/tests/sharepoint/rest/files.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { Files, File, Versions, Version } from "../../../src/sharepoint/rest/files";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Files", () => {
 
@@ -17,14 +18,14 @@ describe("Files", () => {
 
     describe("url", () => {
         it("Should return _api/web/files", () => {
-            expect(files.toUrl()).to.equal("_api/web/files");
+            expect(files.toUrl()).to.match(toMatchEndRegex("_api/web/files"));
         });
     });
 
     describe("getByName", () => {
         it("Should return _api/web/files('Doug Baldwin')", () => {
-           let file = files.getByName("Doug Baldwin");
-           expect(file.toUrl()).to.equal("_api/web/files('Doug Baldwin')");
+            let file = files.getByName("Doug Baldwin");
+            expect(file.toUrl()).to.match(toMatchEndRegex("_api/web/files('Doug Baldwin')"));
         });
     });
 });
@@ -34,7 +35,7 @@ describe("File", () => {
     let file: File;
 
     beforeEach(() => {
-       file = new File("_api/web/files", "getByName('Thomas Rawls')");
+        file = new File("_api/web/files", "getByName('Thomas Rawls')");
     });
 
     it("Should be an object", () => {
@@ -42,146 +43,147 @@ describe("File", () => {
     });
 
     describe("author", () => {
-       it("Should return _api/web/files/getByName('Thomas Rawls')/author", () => {
-          expect(file.author.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/author");
-       });
+        it("Should return _api/web/files/getByName('Thomas Rawls')/author", () => {
+            expect(file.author.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/author"));
+        });
     });
 
     describe("checkedOutByUser", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/checkedOutByUser", () => {
-            expect(file.checkedOutByUser.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/checkedOutByUser");
+            expect(file.checkedOutByUser.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/checkedOutByUser"));
         });
     });
 
     describe("checkInComment", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/checkInComment", () => {
-            expect(file.checkInComment.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/checkInComment");
+            expect(file.checkInComment.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/checkInComment"));
         });
     });
 
     describe("checkOutType", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/checkOutType", () => {
-            expect(file.checkOutType.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/checkOutType");
+            expect(file.checkOutType.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/checkOutType"));
         });
     });
 
     describe("contentTag", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/contentTag", () => {
-            expect(file.contentTag.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/contentTag");
+            expect(file.contentTag.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/contentTag"));
         });
     });
 
     describe("customizedPageStatus", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/customizedPageStatus", () => {
-            expect(file.customizedPageStatus.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/customizedPageStatus");
+            expect(file.customizedPageStatus.toUrl())
+                .to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/customizedPageStatus"));
         });
     });
 
     describe("eTag", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/eTag", () => {
-            expect(file.eTag.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/eTag");
+            expect(file.eTag.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/eTag"));
         });
     });
 
     describe("exists", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/exists", () => {
-            expect(file.exists.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/exists");
+            expect(file.exists.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/exists"));
         });
     });
 
     describe("length", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/length", () => {
-            expect(file.length.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/length");
+            expect(file.length.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/length"));
         });
     });
 
     describe("level", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/level", () => {
-            expect(file.level.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/level");
+            expect(file.level.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/level"));
         });
     });
 
     describe("listItemAllFields", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/listItemAllFields", () => {
-            expect(file.listItemAllFields.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/listItemAllFields");
+            expect(file.listItemAllFields.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/listItemAllFields"));
         });
     });
 
     describe("lockedByUser", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/lockedByUser", () => {
-            expect(file.lockedByUser.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/lockedByUser");
+            expect(file.lockedByUser.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/lockedByUser"));
         });
     });
 
     describe("majorVersion", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/majorVersion", () => {
-            expect(file.majorVersion.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/majorVersion");
+            expect(file.majorVersion.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/majorVersion"));
         });
     });
 
     describe("minorVersion", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/minorVersion", () => {
-            expect(file.minorVersion.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/minorVersion");
+            expect(file.minorVersion.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/minorVersion"));
         });
     });
 
     describe("modifiedBy", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/modifiedBy", () => {
-            expect(file.modifiedBy.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/modifiedBy");
+            expect(file.modifiedBy.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/modifiedBy"));
         });
     });
 
     describe("name", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/name", () => {
-            expect(file.name.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/name");
+            expect(file.name.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/name"));
         });
     });
 
     describe("serverRelativeUrl", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/serverRelativeUrl", () => {
-            expect(file.serverRelativeUrl.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/serverRelativeUrl");
+            expect(file.serverRelativeUrl.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/serverRelativeUrl"));
         });
     });
 
     describe("timeCreated", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/timeCreated", () => {
-            expect(file.timeCreated.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/timeCreated");
+            expect(file.timeCreated.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/timeCreated"));
         });
     });
 
     describe("timeLastModified", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/timeLastModified", () => {
-            expect(file.timeLastModified.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/timeLastModified");
+            expect(file.timeLastModified.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/timeLastModified"));
         });
     });
 
     describe("title", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/title", () => {
-            expect(file.title.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/title");
+            expect(file.title.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/title"));
         });
     });
 
     describe("uiVersion", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/uiVersion", () => {
-            expect(file.uiVersion.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/uiVersion");
+            expect(file.uiVersion.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/uiVersion"));
         });
     });
 
     describe("uiVersionLabel", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/uiVersionLabel", () => {
-            expect(file.uiVersionLabel.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/uiVersionLabel");
+            expect(file.uiVersionLabel.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/uiVersionLabel"));
         });
     });
 
     describe("versions", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/versions", () => {
-            expect(file.versions.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/versions");
+            expect(file.versions.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/versions"));
         });
     });
 
     describe("value", () => {
         it("Should return _api/web/files/getByName('Thomas Rawls')/$value", () => {
-            expect(file.value.toUrl()).to.equal("_api/web/files/getByName('Thomas Rawls')/$value");
+            expect(file.value.toUrl()).to.match(toMatchEndRegex("_api/web/files/getByName('Thomas Rawls')/$value"));
         });
     });
 });
@@ -191,7 +193,7 @@ describe("Versions", () => {
     let versions: Versions;
 
     beforeEach(() => {
-       versions = new Versions("_api/web/getFileByServerRelativeUrl('Earl Thomas')");
+        versions = new Versions("_api/web/getFileByServerRelativeUrl('Earl Thomas')");
     });
 
     it("Should be an object", () => {
@@ -200,15 +202,15 @@ describe("Versions", () => {
 
     describe("url", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Earl Thomas')/versions", () => {
-            expect(versions.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Earl Thomas')/versions");
+            expect(versions.toUrl()).to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Earl Thomas')/versions"));
         });
     });
 
     describe("getById", () => {
-       it("Should return _api/web/getFileByServerRelativeUrl('Earl Thomas')/versions(1)", () => {
-           let version = versions.getById(1);
-           expect(version.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Earl Thomas')/versions(1)");
-       });
+        it("Should return _api/web/getFileByServerRelativeUrl('Earl Thomas')/versions(1)", () => {
+            let version = versions.getById(1);
+            expect(version.toUrl()).to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Earl Thomas')/versions(1)"));
+        });
     });
 });
 
@@ -217,7 +219,7 @@ describe("Version", () => {
     let version: Version;
 
     beforeEach(() => {
-       version = new Version("_api/web/getFileByServerRelativeUrl('Richard Sherman')", "versions(1)");
+        version = new Version("_api/web/getFileByServerRelativeUrl('Richard Sherman')", "versions(1)");
     });
 
     it("Should be an object", () => {
@@ -227,51 +229,55 @@ describe("Version", () => {
     describe("checkInComment", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/checkInComment", () => {
             expect(version.checkInComment.toUrl())
-            .to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/checkInComment");
-       });
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/checkInComment"));
+        });
     });
 
     describe("created", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/created", () => {
-            expect(version.created.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/created");
-       });
+            expect(version.created.toUrl())
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/created"));
+        });
     });
 
     describe("createdBy", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/createdBy", () => {
-            expect(version.createdBy.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/createdBy");
-       });
+            expect(version.createdBy.toUrl())
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/createdBy"));
+        });
     });
 
     describe("id", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/id", () => {
-            expect(version.id.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/id");
-       });
+            expect(version.id.toUrl())
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/id"));
+        });
     });
 
     describe("isCurrentVersion", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/isCurrentVersion", () => {
             expect(version.isCurrentVersion.toUrl())
-            .to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/isCurrentVersion");
-       });
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/isCurrentVersion"));
+        });
     });
 
     describe("size", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/size", () => {
-            expect(version.size.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/size");
-       });
+            expect(version.size.toUrl())
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/size"));
+        });
     });
 
     describe("url", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/url", () => {
-            expect(version.url.toUrl()).to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/url");
-       });
+            expect(version.url.toUrl()).to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/url"));
+        });
     });
 
     describe("versionLabel", () => {
         it("Should return _api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/versionLabel", () => {
             expect(version.versionLabel.toUrl())
-                .to.equal("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/versionLabel");
-       });
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('Richard Sherman')/versions(1)/versionLabel"));
+        });
     });
 });

--- a/tests/sharepoint/rest/folders.test.ts
+++ b/tests/sharepoint/rest/folders.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { Folders, Folder } from "../../../src/sharepoint/rest/folders";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Folders", () => {
 
@@ -17,14 +18,14 @@ describe("Folders", () => {
 
     describe("url", () => {
         it("Should return _api/web/folders", () => {
-            expect(folders.toUrl()).to.equal("_api/web/folders");
+            expect(folders.toUrl()).to.match(toMatchEndRegex("_api/web/folders"));
         });
     });
 
     describe("getByName", () => {
         it("Should return _api/web/folders('Russell Wilson')", () => {
-           let folder = folders.getByName("Russell Wilson");
-           expect(folder.toUrl()).to.equal("_api/web/folders('Russell Wilson')");
+            let folder = folders.getByName("Russell Wilson");
+            expect(folder.toUrl()).to.match(toMatchEndRegex("_api/web/folders('Russell Wilson')"));
         });
     });
 });
@@ -34,7 +35,7 @@ describe("Folder", () => {
     let folder: Folder;
 
     beforeEach(() => {
-       folder = new Folder("_api/web/folders", "getByName('Marshawn Lynch')");
+        folder = new Folder("_api/web/folders", "getByName('Marshawn Lynch')");
     });
 
     it("Should be an object", () => {
@@ -43,67 +44,71 @@ describe("Folder", () => {
 
     describe("contentTypeOrder", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/contentTypeOrder", () => {
-            expect(folder.contentTypeOrder.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/contentTypeOrder");
+            expect(folder.contentTypeOrder.toUrl())
+                .to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/contentTypeOrder"));
         });
     });
 
     describe("files", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/files", () => {
-            expect(folder.files.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/files");
+            expect(folder.files.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/files"));
         });
     });
 
     describe("folders", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/folders", () => {
-            expect(folder.folders.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/folders");
+            expect(folder.folders.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/folders"));
         });
     });
 
     describe("itemCount", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/itemCount", () => {
-            expect(folder.itemCount.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/itemCount");
+            expect(folder.itemCount.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/itemCount"));
         });
     });
 
     describe("listItemAllFields", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/listItemAllFields", () => {
-            expect(folder.listItemAllFields.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/listItemAllFields");
+            expect(folder.listItemAllFields.toUrl())
+                .to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/listItemAllFields"));
         });
     });
 
     describe("name", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/name", () => {
-            expect(folder.name.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/name");
+            expect(folder.name.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/name"));
         });
     });
 
     describe("parentFolder", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/parentFolder", () => {
-            expect(folder.parentFolder.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/parentFolder");
+            expect(folder.parentFolder.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/parentFolder"));
         });
     });
 
     describe("properties", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/properties", () => {
-            expect(folder.properties.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/properties");
+            expect(folder.properties.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/properties"));
         });
     });
 
     describe("serverRelativeUrl", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/serverRelativeUrl", () => {
-            expect(folder.serverRelativeUrl.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/serverRelativeUrl");
+            expect(folder.serverRelativeUrl.toUrl())
+                .to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/serverRelativeUrl"));
         });
     });
 
     describe("uniqueContentTypeOrder", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/uniqueContentTypeOrder", () => {
-            expect(folder.uniqueContentTypeOrder.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/uniqueContentTypeOrder");
+            expect(folder.uniqueContentTypeOrder.toUrl())
+                .to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/uniqueContentTypeOrder"));
         });
     });
 
     describe("welcomePage", () => {
         it("Should return _api/web/folders/getByName('Marshawn Lynch')/welcomePage", () => {
-            expect(folder.welcomePage.toUrl()).to.equal("_api/web/folders/getByName('Marshawn Lynch')/welcomePage");
+            expect(folder.welcomePage.toUrl()).to.match(toMatchEndRegex("_api/web/folders/getByName('Marshawn Lynch')/welcomePage"));
         });
     });
 });

--- a/tests/sharepoint/rest/items.test.ts
+++ b/tests/sharepoint/rest/items.test.ts
@@ -3,6 +3,7 @@
 import { Util } from "../../../src/utils/util";
 import { expect } from "chai";
 import { Items, Item } from "../../../src/sharepoint/rest/items";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Items", () => {
 
@@ -20,13 +21,13 @@ describe("Items", () => {
     describe("url", () => {
         let path = Util.combinePaths(basePath, "items");
         it("Should return " + path, () => {
-            expect(items.toUrl()).to.equal(path);
+            expect(items.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
     describe("getById", () => {
         let path = Util.combinePaths(basePath, "items(1)");
         it("Should return " + path, () => {
-            expect(items.getById(1).toUrl()).to.equal(path);
+            expect(items.getById(1).toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 });
@@ -47,56 +48,56 @@ describe("Item", () => {
     describe("attachmentFiles", () => {
         let path = Util.combinePaths(basePath, "AttachmentFiles");
         it("Should return " + path, () => {
-            expect(item.attachmentFiles.toUrl()).to.equal(path);
+            expect(item.attachmentFiles.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("contentType", () => {
         let path = Util.combinePaths(basePath, "ContentType");
         it("Should return " + path, () => {
-            expect(item.contentType.toUrl()).to.equal(path);
+            expect(item.contentType.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("effectiveBasePermissions", () => {
         let path = Util.combinePaths(basePath, "EffectiveBasePermissions");
         it("Should return " + path, () => {
-            expect(item.effectiveBasePermissions.toUrl()).to.equal(path);
+            expect(item.effectiveBasePermissions.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("effectiveBasePermissionsForUI", () => {
         let path = Util.combinePaths(basePath, "EffectiveBasePermissionsForUI");
         it("Should return " + path, () => {
-            expect(item.effectiveBasePermissionsForUI.toUrl()).to.equal(path);
+            expect(item.effectiveBasePermissionsForUI.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("fieldValuesAsHTML", () => {
         let path = Util.combinePaths(basePath, "FieldValuesAsHTML");
         it("Should return " + path, () => {
-            expect(item.fieldValuesAsHTML.toUrl()).to.equal(path);
+            expect(item.fieldValuesAsHTML.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("fieldValuesAsText", () => {
         let path = Util.combinePaths(basePath, "FieldValuesAsText");
         it("Should return " + path, () => {
-            expect(item.fieldValuesAsText.toUrl()).to.equal(path);
+            expect(item.fieldValuesAsText.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("fieldValuesForEdit", () => {
         let path = Util.combinePaths(basePath, "FieldValuesForEdit");
         it("Should return " + path, () => {
-            expect(item.fieldValuesForEdit.toUrl()).to.equal(path);
+            expect(item.fieldValuesForEdit.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 
     describe("folder", () => {
         let path = Util.combinePaths(basePath, "Folder");
         it("Should return " + path, () => {
-            expect(item.folder.toUrl()).to.equal(path);
+            expect(item.folder.toUrl()).to.match(toMatchEndRegex(path));
         });
     });
 });

--- a/tests/sharepoint/rest/lists.test.ts
+++ b/tests/sharepoint/rest/lists.test.ts
@@ -5,6 +5,7 @@ import { Lists, List } from "../../../src/sharepoint/rest/lists";
 import { ControlMode, PageType } from "../../../src/sharepoint/rest/types";
 import { testSettings } from "../../test-config.test";
 import pnp from "../../../src/pnp";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Lists", () => {
 
@@ -20,28 +21,28 @@ describe("Lists", () => {
 
     describe("url", () => {
         it("Should return _api/web/lists", () => {
-            expect(lists.toUrl()).to.equal("_api/web/lists");
+            expect(lists.toUrl()).to.match(toMatchEndRegex("_api/web/lists"));
         });
     });
 
     describe("getByTitle", () => {
         it("Should return _api/web/lists/getByTitle('Tasks')", () => {
             let list = lists.getByTitle("Tasks");
-            expect(list.toUrl()).to.equal("_api/web/lists/getByTitle('Tasks')");
+            expect(list.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')"));
         });
     });
 
     describe("getById", () => {
         it("Should return _api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')", () => {
             let list = lists.getById("4FC65058-FDDE-4FAD-AB21-2E881E1CF527");
-            expect(list.toUrl()).to.equal("_api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')");
+            expect(list.toUrl()).to.match(toMatchEndRegex("_api/web/lists('4FC65058-FDDE-4FAD-AB21-2E881E1CF527')"));
         });
     });
 
     describe("getById with {}", () => {
         it("Should return _api/web/lists('{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}')", () => {
             let list = lists.getById("{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}");
-            expect(list.toUrl()).to.equal("_api/web/lists('{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}')");
+            expect(list.toUrl()).to.match(toMatchEndRegex("_api/web/lists('{4FC65058-FDDE-4FAD-AB21-2E881E1CF527}')"));
         });
     });
 
@@ -110,70 +111,71 @@ describe("List", () => {
 
     describe("contentTypes", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/contenttypes", () => {
-            expect(list.contentTypes.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/contenttypes");
+            expect(list.contentTypes.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/contenttypes"));
         });
     });
 
     describe("items", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/items", () => {
-            expect(list.items.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/items");
+            expect(list.items.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/items"));
         });
     });
 
     describe("views", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/views", () => {
-            expect(list.views.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/views");
+            expect(list.views.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/views"));
         });
     });
 
     describe("fields", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/fields", () => {
-            expect(list.fields.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/fields");
+            expect(list.fields.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/fields"));
         });
     });
 
     describe("defaultView", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/DefaultView", () => {
-            expect(list.defaultView.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/DefaultView");
+            expect(list.defaultView.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/DefaultView"));
         });
     });
 
     describe("effectiveBasePermissions", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/EffectiveBasePermissions", () => {
-            expect(list.effectiveBasePermissions.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/EffectiveBasePermissions");
+            expect(list.effectiveBasePermissions.toUrl())
+                .to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/EffectiveBasePermissions"));
         });
     });
 
     describe("eventReceivers", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/EventReceivers", () => {
-            expect(list.eventReceivers.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/EventReceivers");
+            expect(list.eventReceivers.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/EventReceivers"));
         });
     });
 
     describe("relatedFields", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/getRelatedFields", () => {
-            expect(list.relatedFields.toUrl()).to.eq("_api/web/lists/getByTitle('Tasks')/getRelatedFields");
+            expect(list.relatedFields.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/getRelatedFields"));
         });
     });
 
     describe("informationRightsManagementSettings", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/InformationRightsManagementSettings", () => {
             expect(list.informationRightsManagementSettings.toUrl())
-                .to.eq("_api/web/lists/getByTitle('Tasks')/InformationRightsManagementSettings");
+                .to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/InformationRightsManagementSettings"));
         });
     });
 
     describe("userCustomActions", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/usercustomactions", () => {
             expect(list.userCustomActions.toUrl())
-                .to.eq("_api/web/lists/getByTitle('Tasks')/usercustomactions");
+                .to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/usercustomactions"));
         });
     });
 
     describe("getView", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/getView('b81b1b32-ed0a-4b80-bd16-67c99a4f3c1c')", () => {
             expect(list.getView("b81b1b32-ed0a-4b80-bd16-67c99a4f3c1c").toUrl())
-                .to.eq("_api/web/lists/getByTitle('Tasks')/getView('b81b1b32-ed0a-4b80-bd16-67c99a4f3c1c')");
+                .to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/getView('b81b1b32-ed0a-4b80-bd16-67c99a4f3c1c')"));
         });
     });
 
@@ -236,7 +238,7 @@ describe("List", () => {
         describe("informationRightsManagementSettings", () => {
             it("should return the information rights management settings from the list", () => {
                 return expect(pnp.sp.web.lists.getByTitle("Documents").informationRightsManagementSettings.get())
-                .to.eventually.be.fulfilled;
+                    .to.eventually.be.fulfilled;
             });
         });
 

--- a/tests/sharepoint/rest/navigation.test.ts
+++ b/tests/sharepoint/rest/navigation.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { Navigation } from "../../../src/sharepoint/rest/navigation";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Navigation", () => {
     it("Should be an object", () => {
@@ -11,7 +12,7 @@ describe("Navigation", () => {
     describe("url", () => {
         it("Should return _api/web/Navigation", () => {
             let navigation = new Navigation("_api/web");
-            expect(navigation.toUrl()).to.equal("_api/web/navigation");
+            expect(navigation.toUrl()).to.match(toMatchEndRegex("_api/web/navigation"));
         });
     });
 });

--- a/tests/sharepoint/rest/quicklaunch.test.ts
+++ b/tests/sharepoint/rest/quicklaunch.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { QuickLaunch } from "../../../src/sharepoint/rest/quickLaunch";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("QuickLaunch", () => {
     it("Should be an object", () => {
@@ -11,7 +12,7 @@ describe("QuickLaunch", () => {
     describe("url", () => {
         it("Should return _api/web/Navigation/QuickLaunch", () => {
             let quickLaunch = new QuickLaunch("_api/web/Navigation");
-            expect(quickLaunch.toUrl()).to.equal("_api/web/Navigation/QuickLaunch");
+            expect(quickLaunch.toUrl()).to.match(toMatchEndRegex("_api/web/Navigation/QuickLaunch"));
         });
     });
 });

--- a/tests/sharepoint/rest/roles.test.ts
+++ b/tests/sharepoint/rest/roles.test.ts
@@ -4,8 +4,9 @@ import { expect } from "chai";
 import {
     RoleAssignment,
     RoleAssignments,
-    RoleDefinitions
+    RoleDefinitions,
 } from "../../../src/sharepoint/rest/roles";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("RoleAssignments", () => {
     it("Should be an object", () => {
@@ -16,14 +17,14 @@ describe("RoleAssignments", () => {
     describe("url", () => {
         it("Should return _api/web/roleassignments", () => {
             let roleAssignments = new RoleAssignments("_api/web");
-            expect(roleAssignments.toUrl()).to.equal("_api/web/roleassignments");
+            expect(roleAssignments.toUrl()).to.match(toMatchEndRegex("_api/web/roleassignments"));
         });
     });
 
     describe("getById", () => {
         it("Should return _api/web/roleassignments(1)", () => {
             let roleAssignments = new RoleAssignments("_api/web");
-            expect(roleAssignments.getById(1).toUrl()).to.equal("_api/web/roleassignments(1)");
+            expect(roleAssignments.getById(1).toUrl()).to.match(toMatchEndRegex("_api/web/roleassignments(1)"));
         });
     });
 });
@@ -40,14 +41,14 @@ describe("RoleAssignment", () => {
     describe("groups", () => {
         it("Should return " + baseUrl + "/groups", () => {
             let roleAssignment = new RoleAssignment(baseUrl);
-            expect(roleAssignment.groups.toUrl()).to.equal(baseUrl + "/groups");
+            expect(roleAssignment.groups.toUrl()).to.match(toMatchEndRegex(baseUrl + "/groups"));
         });
     });
 
     describe("bindings", () => {
         it("Should return " + baseUrl + "/roledefinitionbindings", () => {
             let roleAssignment = new RoleAssignment(baseUrl);
-            expect(roleAssignment.bindings.toUrl()).to.equal(baseUrl + "/roledefinitionbindings");
+            expect(roleAssignment.bindings.toUrl()).to.match(toMatchEndRegex(baseUrl + "/roledefinitionbindings"));
         });
     });
 });
@@ -68,19 +69,19 @@ describe("RoleDefinitions", () => {
 
     describe("getById", () => {
         it("Should return " + baseUrl + "/roledefinitions/getById(1)", () => {
-            expect(roleDefinitions.getById(1).toUrl()).to.equal(baseUrl + "/roledefinitions/getById(1)");
+            expect(roleDefinitions.getById(1).toUrl()).to.match(toMatchEndRegex(baseUrl + "/roledefinitions/getById(1)"));
         });
     });
 
     describe("getByName", () => {
         it("Should return " + baseUrl + "/getbyname('name')", () => {
-            expect(roleDefinitions.getByName("name").toUrl()).to.equal(baseUrl + "/roledefinitions/getbyname('name')");
+            expect(roleDefinitions.getByName("name").toUrl()).to.match(toMatchEndRegex(baseUrl + "/roledefinitions/getbyname('name')"));
         });
     });
 
     describe("getByType", () => {
         it("Should return " + baseUrl + "/getbytype(1)", () => {
-            expect(roleDefinitions.getByType(1).toUrl()).to.equal(baseUrl + "/roledefinitions/getbytype(1)");
+            expect(roleDefinitions.getByType(1).toUrl()).to.match(toMatchEndRegex(baseUrl + "/roledefinitions/getbytype(1)"));
         });
     });
 });

--- a/tests/sharepoint/rest/sitegroups.test.ts
+++ b/tests/sharepoint/rest/sitegroups.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { SiteGroup, SiteGroups } from "../../../src/sharepoint/rest/siteGroups";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("SiteGroups", () => {
     it("Should be an object", () => {
@@ -12,21 +13,21 @@ describe("SiteGroups", () => {
     describe("url", () => {
         it("Should return _api/web/sitegroups", () => {
             let siteGroups = new SiteGroups("_api/web");
-            expect(siteGroups.toUrl()).to.equal("_api/web/sitegroups");
+            expect(siteGroups.toUrl()).to.match(toMatchEndRegex("_api/web/sitegroups"));
         });
     });
 
     describe("getById", () => {
         it("Should return _api/web/sitegroups(12)", () => {
             let group = new SiteGroups("_api/web").getById(12);
-            expect(group.toUrl()).to.equal("_api/web/sitegroups(12)");
+            expect(group.toUrl()).to.match(toMatchEndRegex("_api/web/sitegroups(12)"));
         });
     });
 
     describe("getByName", () => {
         it("Should return _api/web/sitegroups/getByName('Group Name')", () => {
             let group = new SiteGroups("_api/web").getByName("Group Name");
-            expect(group.toUrl()).to.equal("_api/web/sitegroups/getByName('Group Name')");
+            expect(group.toUrl()).to.match(toMatchEndRegex("_api/web/sitegroups/getByName('Group Name')"));
         });
     });
 });
@@ -45,13 +46,13 @@ describe("SiteGroup", () => {
 
     describe("url", () => {
         it("Should return _api/web/sitegroups(1)", () => {
-            expect(group.toUrl()).to.equal("_api/web/sitegroups(1)");
+            expect(group.toUrl()).to.match(toMatchEndRegex("_api/web/sitegroups(1)"));
         });
     });
 
     describe("users", () => {
         it("Should return _api/web/sitegroups", () => {
-            expect(group.users.toUrl()).to.equal("_api/web/sitegroups(1)/users");
+            expect(group.users.toUrl()).to.match(toMatchEndRegex("_api/web/sitegroups(1)/users"));
         });
     });
 });

--- a/tests/sharepoint/rest/siteusers.test.ts
+++ b/tests/sharepoint/rest/siteusers.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { SiteUser, SiteUsers } from "../../../src/sharepoint/rest/siteUsers";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("SiteUsers", () => {
 
@@ -17,28 +18,28 @@ describe("SiteUsers", () => {
 
     describe("url", () => {
         it("Should return _api/web/siteusers", () => {
-            expect(users.toUrl()).to.equal("_api/web/siteusers");
+            expect(users.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers"));
         });
     });
 
     describe("getByEmail", () => {
         it("Should return _api/web/siteusers/getByEmail('user@user.com')", () => {
             let user = users.getByEmail("user@user.com");
-            expect(user.toUrl()).to.equal("_api/web/siteusers/getByEmail('user@user.com')");
+            expect(user.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers/getByEmail('user@user.com')"));
         });
     });
 
     describe("getById", () => {
         it("Should return _api/web/siteusers/getById(12)", () => {
             let user = users.getById(12);
-            expect(user.toUrl()).to.equal("_api/web/siteusers/getById(12)");
+            expect(user.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers/getById(12)"));
         });
     });
 
     describe("getByLoginName", () => {
         it("Should return _api/web/siteusers(@v)?@v=i%3A0%23.f%7Cmembership%7Cuser%40tenant.com", () => {
             let user = users.getByLoginName("i:0#.f|membership|user@tenant.com");
-            expect(user.toUrlAndQuery()).to.equal("_api/web/siteusers(@v)?@v=i%3A0%23.f%7Cmembership%7Cuser%40tenant.com");
+            expect(user.toUrlAndQuery()).to.match(toMatchEndRegex("_api/web/siteusers(@v)?@v=i%3A0%23.f%7Cmembership%7Cuser%40tenant.com"));
         });
     });
 });
@@ -57,13 +58,13 @@ describe("SiteUser", () => {
 
     describe("url", () => {
         it("Should return _api/web/siteusers/getById(2)", () => {
-            expect(user.toUrl()).to.equal("_api/web/siteusers/getById(2)");
+            expect(user.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers/getById(2)"));
         });
     });
 
     describe("groups", () => {
         it("Should return _api/web/siteusers/getById(2)/groups", () => {
-            expect(user.groups.toUrl()).to.equal("_api/web/siteusers/getById(2)/groups");
+            expect(user.groups.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers/getById(2)/groups"));
         });
     });
 });

--- a/tests/sharepoint/rest/topnavigationbar.test.ts
+++ b/tests/sharepoint/rest/topnavigationbar.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { TopNavigationBar } from "../../../src/sharepoint/rest/topNavigationBar";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("TopNavigationBar", () => {
     it("Should be an object", () => {
@@ -11,7 +12,7 @@ describe("TopNavigationBar", () => {
     describe("url", () => {
         it("Should return _api/web/Navigation/TopNavigationBar", () => {
             let topNavigationBar = new TopNavigationBar("_api/web/Navigation");
-            expect(topNavigationBar.toUrl()).to.equal("_api/web/Navigation/TopNavigationBar");
+            expect(topNavigationBar.toUrl()).to.match(toMatchEndRegex("_api/web/Navigation/TopNavigationBar"));
         });
     });
 });

--- a/tests/sharepoint/rest/views.test.ts
+++ b/tests/sharepoint/rest/views.test.ts
@@ -2,6 +2,7 @@
 
 import { expect } from "chai";
 import { Views } from "../../../src/sharepoint/rest/views";
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Views", () => {
     it("Should be an object", () => {
@@ -11,14 +12,15 @@ describe("Views", () => {
     describe("url", () => {
         it("Should return _api/web/lists/getByTitle('Tasks')/Views", () => {
             let views = new Views("_api/web/lists/getByTitle('Tasks')");
-            expect(views.toUrl()).to.equal("_api/web/lists/getByTitle('Tasks')/views");
+            expect(views.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/views"));
         });
     });
     describe("getById", () => {
         it("Should return _api/web/lists/getByTitle('Tasks')/Views('7b7c777e-b749-4f58-a825-53084f2941b0')", () => {
             let views = new Views("_api/web/lists/getByTitle('Tasks')");
             let view = views.getById("7b7c777e-b749-4f58-a825-53084f2941b0");
-            expect(view.toUrl()).to.equal("_api/web/lists/getByTitle('Tasks')/views('7b7c777e-b749-4f58-a825-53084f2941b0')");
+            expect(view.toUrl())
+                .to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/views('7b7c777e-b749-4f58-a825-53084f2941b0')"));
         });
     });
 });

--- a/tests/sharepoint/rest/web.test.ts
+++ b/tests/sharepoint/rest/web.test.ts
@@ -5,7 +5,7 @@ import { testSettings } from "../../test-config.test";
 import { expect } from "chai";
 import { Web } from "../../../src/sharepoint/rest/webs";
 import { Util } from "../../../src/utils/util";
-
+import { toMatchEndRegex } from "../../testutils";
 
 describe("Webs", () => {
 
@@ -35,76 +35,76 @@ describe("Web", () => {
 
     describe("url", () => {
         it("Should return _api/web", () => {
-            expect(web.toUrl()).to.equal("_api/web");
+            expect(web.toUrl()).to.match(toMatchEndRegex("_api/web"));
         });
     });
 
     describe("webs", () => {
         it("should return _api/web/webs", () => {
-            expect(web.webs.toUrl()).to.eq("_api/web/webs");
+            expect(web.webs.toUrl()).to.match(toMatchEndRegex("_api/web/webs"));
         });
     });
 
     describe("contentTypes", () => {
         it("should return _api/web/contenttypes", () => {
-            expect(web.contentTypes.toUrl()).to.eq("_api/web/contenttypes");
+            expect(web.contentTypes.toUrl()).to.match(toMatchEndRegex("_api/web/contenttypes"));
         });
     });
 
     describe("lists", () => {
-        it("should return _api/web/lists", function () {
-            expect(web.lists.toUrl()).to.eq("_api/web/lists");
+        it("should return _api/web/lists", () => {
+            expect(web.lists.toUrl()).to.match(toMatchEndRegex("_api/web/lists"));
         });
     });
 
     describe("navigation", () => {
         it("should return _api/web/navigation", () => {
-            expect(web.navigation.toUrl()).to.eq("_api/web/navigation");
+            expect(web.navigation.toUrl()).to.match(toMatchEndRegex("_api/web/navigation"));
         });
     });
 
     describe("siteUsers", () => {
         it("should return _api/web/siteUsers", () => {
-            expect(web.siteUsers.toUrl()).to.eq("_api/web/siteusers");
+            expect(web.siteUsers.toUrl()).to.match(toMatchEndRegex("_api/web/siteusers"));
         });
     });
 
     describe("folders", () => {
         it("should return _api/web/folders", () => {
-            expect(web.folders.toUrl()).to.eq("_api/web/folders");
+            expect(web.folders.toUrl()).to.match(toMatchEndRegex("_api/web/folders"));
         });
     });
 
     describe("getFolderByServerRelativeUrl", () => {
         it("should return _api/web/getFolderByServerRelativeUrl('/sites/dev/shared documents/folder')", () => {
             expect(web.getFolderByServerRelativeUrl("/sites/dev/shared documents/folder").toUrl())
-                .to.eq("_api/web/getFolderByServerRelativeUrl('/sites/dev/shared documents/folder')");
+                .to.match(toMatchEndRegex("_api/web/getFolderByServerRelativeUrl('/sites/dev/shared documents/folder')"));
         });
     });
 
     describe("getFileByServerRelativeUrl", () => {
         it("should return _api/web/getFileByServerRelativeUrl('/sites/dev/shared documents/folder/doc.docx')", () => {
             expect(web.getFileByServerRelativeUrl("/sites/dev/shared documents/folder/doc.docx").toUrl())
-                .to.eq("_api/web/getFileByServerRelativeUrl('/sites/dev/shared documents/folder/doc.docx')");
+                .to.match(toMatchEndRegex("_api/web/getFileByServerRelativeUrl('/sites/dev/shared documents/folder/doc.docx')"));
         });
     });
 
     describe("availableWebTemplates", () => {
         it("should return _api/web/getavailablewebtemplates(lcid=1033, doincludecrosslanguage=true)", () => {
             expect(web.availableWebTemplates(1033, true).toUrl())
-                .to.eq("_api/web/getavailablewebtemplates(lcid=1033, doincludecrosslanguage=true)");
+                .to.match(toMatchEndRegex("_api/web/getavailablewebtemplates(lcid=1033, doincludecrosslanguage=true)"));
         });
     });
 
     describe("customListTemplate", () => {
         it("should return _api/web/getcustomlisttemplates", () => {
-            expect(web.customListTemplate.toUrl()).to.eq("_api/web/getcustomlisttemplates");
+            expect(web.customListTemplate.toUrl()).to.match(toMatchEndRegex("_api/web/getcustomlisttemplates"));
         });
     });
 
     describe("getUserById", () => {
         it("should return _api/web/getUserById(4)", () => {
-            expect(web.getUserById(4).toUrl()).to.eq("_api/web/getUserById(4)");
+            expect(web.getUserById(4).toUrl()).to.match(toMatchEndRegex("_api/web/getUserById(4)"));
         });
     });
 

--- a/tests/test-config.test.ts
+++ b/tests/test-config.test.ts
@@ -12,7 +12,7 @@ export let testSettings = Util.extend(global.settings.testing, { webUrl: ""  });
 before(function (done: MochaDone) {
 
     // this may take some time, don't timeout early
-    this.timeout(30000);
+    this.timeout(90000);
 
     // establish the connection to sharepoint
     if (testSettings.enableWebTests) {
@@ -25,9 +25,8 @@ before(function (done: MochaDone) {
             },
         });
 
-        // this.timeout(90000);
-        // cleanUpAllSubsites();
-        // throw new Error("stop");
+        // comment this out to keep older subsites
+        cleanUpAllSubsites();
 
         // create the web in which we will test
         let d = new Date();
@@ -78,5 +77,5 @@ export function cleanUpAllSubsites() {
                     }));
             }).then(() => { web.delete(); });
         });
-    });
+    }).catch(e => console.log("Error: " + JSON.stringify(e)));
 }

--- a/tests/testutils.ts
+++ b/tests/testutils.ts
@@ -1,0 +1,11 @@
+/**
+ * Used to create an escaped regex for the non-SharePoint request tests 
+ * 
+ */
+export function toMatchEndRegex(s: string): RegExp {
+    let s2 = s.replace(/\(/g, "\\(");
+    s2 = s2.replace(/\)/g, "\\)");
+    s2 = s2.replace(/\?/g, "\\?");
+    s2 = s2.replace(/\$/g, "\\$");
+    return new RegExp(s2 + "$");
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | No
| New sample?      | No
| Related issues?  | none

#### What's in this Pull Request?

This PR fixes the static url tests which were broken when the code was updated to make the urls absolute when using the node request client. Change was to match the end of the url using regex instead of equals.

