### PR TITLE
Web is extended with getList method for retrieving lists by Url

### DIFF
--- a/src/sharepoint/rest/webs.ts
+++ b/src/sharepoint/rest/webs.ts
@@ -184,6 +184,15 @@ export class Web extends QueryableSecurable {
     }
 
     /**
+     * Get a list by server relative url (list's root folder)
+     *
+     * @param listRelativeUrl the server relative path to the list's root folder (including /sites/ if applicable)
+     */
+    public getList(listRelativeUrl: string): List {
+        return new List(this, `getList('${listRelativeUrl}')`);
+    }
+
+    /**
      * Updates this web intance with the supplied properties
      *
      * @param properties A plain object hash of values to update for the web

--- a/tests/sharepoint/rest/web.test.ts
+++ b/tests/sharepoint/rest/web.test.ts
@@ -89,6 +89,13 @@ describe("Web", () => {
         });
     });
 
+    describe("getList", () => {
+        it("should return _api/web/getList('/sites/dev/lists/customlist')", () => {
+            expect(web.getList("/sites/dev/lists/customlist").toUrl())
+                .to.eq("_api/web/getList('/sites/dev/lists/customlist')");
+        });
+    });
+
     describe("availableWebTemplates", () => {
         it("should return _api/web/getavailablewebtemplates(lcid=1033, doincludecrosslanguage=true)", () => {
             expect(web.availableWebTemplates(1033, true).toUrl())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

This PR adds capability to use web's getList method for getting list base on its relative URL, which is more preferable in compare to pnp.sp.web.lists.getByTitle and simpler to maintain that pnp.sp.web.lists.getById.

#### Guidance

Extends REST API wrapper with web.getList, which allows getting access for the following construction:
pnp.sp.web.getList('/sites/site/lists/customlist')