### PR TITLE
Unable to sort items descending #198 fix

### DIFF
--- a/src/sharepoint/rest/queryable.ts
+++ b/src/sharepoint/rest/queryable.ts
@@ -361,12 +361,12 @@ export class QueryableCollection extends Queryable {
      * Orders based on the supplied fields ascending
      * 
      * @param orderby The name of the field to sort on
-     * @param ascending If true ASC is appended, otherwise DESC (default)
+     * @param ascending If true DESC is appended, otherwise ASC (default)
      */
-    public orderBy(orderBy: string, ascending = false): QueryableCollection {
+    public orderBy(orderBy: string, ascending = true): QueryableCollection {
         let keys = this._query.getKeys();
         let query = [];
-        let asc = ascending ? " asc" : "";
+        let asc = ascending ? " asc" : " desc";
         for (let i = 0; i < keys.length; i++) {
             if (keys[i] === "$orderby") {
                 query.push(this._query.get("$orderby"));

--- a/src/sharepoint/rest/queryable.ts
+++ b/src/sharepoint/rest/queryable.ts
@@ -361,7 +361,7 @@ export class QueryableCollection extends Queryable {
      * Orders based on the supplied fields ascending
      * 
      * @param orderby The name of the field to sort on
-     * @param ascending If true DESC is appended, otherwise ASC (default)
+     * @param ascending If false DESC is appended, otherwise ASC (default)
      */
     public orderBy(orderBy: string, ascending = true): QueryableCollection {
         let keys = this._query.getKeys();

--- a/tests/sharepoint/rest/queryable.test.ts
+++ b/tests/sharepoint/rest/queryable.test.ts
@@ -56,6 +56,20 @@ describe("QueryableCollection", () => {
     });
 
     describe("orderBy", () => {
+        it("Should append a single order by query ascending (default behavior)", () => {
+            queryable.orderBy("Title");
+            expect(queryable.toUrlAndQuery()).to.include("$orderby=Title asc");
+        });
+    });
+
+    describe("orderBy", () => {
+        it("Should append a single order by query descending", () => {
+            queryable.orderBy("Title", false);
+            expect(queryable.toUrlAndQuery()).to.include("$orderby=Title desc");
+        });
+    });
+
+    describe("orderBy", () => {
         it("Should append multiple order by queries", () => {
             queryable.orderBy("Title", true);
             queryable.orderBy("Description");


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #198

#### What's in this Pull Request?

Order by behavior fix.
`When calling pnp.sp.web.list.get().items.orderBy('Id', false) the REST query should contain $orderby=Id desc.
Currently the second parameter in the orderBy function determines whether sorting should be done ascending. Given that that's the default setting, consider changing the second parameter to descending so that when set, it explicitly adds desc to the $orderby clause in the REST query.`

#### Guidance
Descending was a default order due to the description.
Because desc was not added to the api url parameter this didn't work.
With working descending parameters I consider asc to be a default one.

```javascript
// descending
$pnp.sp.web.lists.getByTitle("Custom02").items.orderBy("Title", false).get().then(function(items) {
   items.forEach(function(d) { console.log(d.Title); });
});
/*
Item 9
Item 8
Item 7
...
*/
// ascending - strict parameter
$pnp.sp.web.lists.getByTitle("Custom02").items.orderBy("Title", true).get().then(function(items) {
   items.forEach(function(d) { console.log(d.Title); });
});
/*
Item 1
Item 2
Item 3
...
*/
// ascending - by default
$pnp.sp.web.lists.getByTitle("Custom02").items.orderBy("Title").get().then(function(items) {
   items.forEach(function(d) { console.log(d.Title); });
});
/*
Item 1
Item 2
Item 3
...
*/
```
