### PR TITLE
Added support for obtaining authentication headers through the node-sp-auth

### DIFF
--- a/buildtasks/lint.js
+++ b/buildtasks/lint.js
@@ -21,7 +21,7 @@ var gulp = require("gulp"),
 //******************************************************************************
 
 gulp.task("lint", function () {
-    return gulp.src(global.TSWorkspace.Files)
+    return gulp.src(global.TSWorkspace.TSLint)
         .pipe(tslint({
             formatter: "prose"
         }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,9 +27,14 @@ global.TSWorkspace = {
     "PnPFile": "src/pnp.ts",
     "Files": [
         'src/**/*.ts',
+        'typings/modules/node-sp-auth/index.d.ts'     
+    ],
+    "TSLint": [
+        'src/**/*.ts'
     ],
     "Tests": [
         'tests/**/*.ts',
+        'typings/modules/node-sp-auth/index.d.ts'
     ]
 };
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@types/microsoft-ajax": "0.0.31",
     "@types/sharepoint": "^2013.0.31",
     "@types/whatwg-fetch": "0.0.32",
-    "es6-promise": "^3.0.0"
+    "es6-promise": "^3.0.0",
+    "node-sp-auth": "^1.1.2"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/settings.example.js
+++ b/settings.example.js
@@ -6,10 +6,13 @@ var settings = {
         siteUrl: "https://mydevtenant.sharepoint.com/"
     },
     testing: {
-        clientId: "{ client id }",
-        clientSecret: "{ client secret }",
         enableWebTests: true,
         siteUrl: "{ site collection url }",
+        /* any credentialOptions given by https://github.com/s-KaiNet/node-sp-auth#params */
+        credentials: {
+            clientId: '{ client id }',
+		    clientSecret: '{client secret}'
+        }
     }
 }
 

--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -1,13 +1,13 @@
 "use strict";
 
 import { TypedHash } from "../collections/collections";
+import {IAuthOptions} from "node-sp-auth";
 
 declare var global: any;
 
 export interface NodeClientData {
-    clientId: string;
-    clientSecret: string;
     siteUrl: string;
+    credentials: IAuthOptions;
 }
 
 export interface LibraryConfiguration {

--- a/src/net/httpclient.ts
+++ b/src/net/httpclient.ts
@@ -46,7 +46,7 @@ export class HttpClient {
         }
 
         if (!headers.has("Content-Type")) {
-            headers.append("Content-Type", "application/json;odata=verbose;charset=utf-8");
+            headers.append("Content-Type", "application/json;odata=verbose");
         }
 
         if (!headers.has("X-ClientService-ClientTag")) {
@@ -136,7 +136,7 @@ export class HttpClient {
             return new SPRequestExecutorClient();
         } else if (RuntimeConfig.useNodeFetchClient) {
             let opts = RuntimeConfig.nodeRequestOptions;
-            return new NodeFetchClient(opts.siteUrl, opts.clientId, opts.clientSecret);
+            return new NodeFetchClient(opts.siteUrl, opts.credentials);
         } else {
             return new FetchClient();
         }

--- a/src/net/nodefetchclient.ts
+++ b/src/net/nodefetchclient.ts
@@ -3,29 +3,18 @@
 declare var global: any;
 declare var require: (path: string) => any;
 let nodeFetch = require("node-fetch");
-let u: any = require("url");
 import { HttpClientImpl } from "./httpclient";
 import { Util } from "../utils/util";
-import { Logger, LogLevel } from "../utils/logging";
-
-export interface AuthToken {
-    token_type: string;
-    expires_in: string;
-    not_before: string;
-    expires_on: string;
-    resource: string;
-    access_token: string;
-}
+import * as url from "url";
+import { getAuth, IAuthOptions } from "node-sp-auth";
+import * as https from "https";
 
 /**
  * Fetch client for use within nodejs, requires you register a client id and secret with app only permissions
  */
 export class NodeFetchClient implements HttpClientImpl {
 
-    private static SharePointServicePrincipal: string = "00000003-0000-0ff1-ce00-000000000000";
-    private token: AuthToken = null;
-
-    constructor(public siteUrl: string, private _clientId: string, private _clientSecret: string, private _realm = "") {
+    constructor(public siteUrl: string, private credentials: IAuthOptions) {
 
         // here we "cheat" and set the globals for fetch things when this client is instantiated
         global.Headers = nodeFetch.Headers;
@@ -33,116 +22,32 @@ export class NodeFetchClient implements HttpClientImpl {
         global.Response = nodeFetch.Response;
     }
 
-    public fetch(url: string, options: any): Promise<Response> {
+    public fetch(requesturl: string, options: any): Promise<Response> {
 
-        if (!Util.isUrlAbsolute(url)) {
-            url = Util.combinePaths(this.siteUrl, url);
+        if (!Util.isUrlAbsolute(requesturl)) {
+            requesturl = Util.combinePaths(this.siteUrl, requesturl);
         }
 
-        return this.getAddInOnlyAccessToken().then(token => {
-            options.headers.set("Authorization", `Bearer ${token.access_token}`);
-            return nodeFetch(url, options);
-        });
-    }
+        return getAuth(requesturl, this.credentials).then(authResult => {
 
-    /**
-     * Gets an add-in only authentication token based on the supplied site url, client id and secret
-     */
-    public getAddInOnlyAccessToken(): Promise<AuthToken> {
-
-        if (this.token !== null && new Date() < this.toDate(this.token.expires_on)) {
-            return new Promise<AuthToken>(r => r(this.token));
-        }
-
-        return this.getRealm().then(realm => {
-
-            let resource = this.getFormattedPrincipal(NodeFetchClient.SharePointServicePrincipal, u.parse(this.siteUrl).hostname, realm);
-            let formattedClientId = this.getFormattedPrincipal(this._clientId, "", realm);
-
-            return this.getAuthUrl(realm).then((authUrl: string) => {
-
-                let body = [];
-                body.push("grant_type=client_credentials");
-                body.push(`client_id=${formattedClientId}`);
-                body.push(`client_secret=${encodeURIComponent(this._clientSecret)}`);
-                body.push(`resource=${resource}`);
-
-                return nodeFetch(authUrl, {
-                    body: body.join("&"),
-                    headers: {
-                        "Content-Type": "application/x-www-form-urlencoded",
-                    },
-                    method: "POST",
-                }).then((r: Response) => r.json()).then(tok => {
-                    this.token = tok;
-                    return this.token;
-                });
-            });
-        });
-    }
-
-    private getRealm(): Promise<string> {
-
-        return new Promise(resolve => {
-
-            if (this._realm.length > 0) {
-                resolve(this._realm);
-            }
-
-            let url = Util.combinePaths(this.siteUrl, "vti_bin/client.svc");
-
-            nodeFetch(url, {
-                "method": "POST",
-                "headers": {
-                    "Authorization": "Bearer ",
-                },
-            }).then((r) => {
-
-                let data: string = r.headers.get("www-authenticate");
-                let index = data.indexOf("Bearer realm=\"");
-                this._realm = data.substring(index + 14, index + 50);
-                resolve(this._realm);
-            });
-        });
-    }
-
-    private getAuthUrl(realm: string): Promise<string> {
-
-        let url = `https://accounts.accesscontrol.windows.net/metadata/json/1?realm=${realm}`;
-
-        return nodeFetch(url).then((r: Response) => r.json()).then((json: { endpoints: { protocol: string, location: string }[] }) => {
-
-            for (let i = 0; i < json.endpoints.length; i++) {
-                if (json.endpoints[i].protocol === "OAuth2") {
-                    return json.endpoints[i].location;
+            if (authResult.options && (<any>authResult.options).agent) {
+                options.agent = (<any>authResult.options).agent;
+            } else {
+                let isHttps: boolean = url.parse(requesturl).protocol === "https:";
+                if (isHttps) {
+                    // bypassing ssl errors like self-signed ssl certifcate, etc, especially for on-premise
+                    options.agent = new https.Agent({ rejectUnauthorized: false });
                 }
             }
 
-            Logger.log({
-                data: json,
-                level: LogLevel.Error,
-                message: "Auth URL Endpoint could not be determined from data. Data logged.",
-            });
-            throw new Error("Auth URL Endpoint could not be determined from data. Data logged.");
+            /* assign headers */
+            for (let propName in authResult.headers) {
+                if ((<any>authResult.headers).hasOwnProperty(propName)) {
+                    options.headers.set(propName, authResult.headers[propName]);
+                }
+            }
+
+            return nodeFetch(requesturl, options);
         });
-    }
-
-    private getFormattedPrincipal(principalName, hostName, realm): string {
-        let resource = principalName;
-        if (hostName !== null && hostName !== "") {
-            resource += "/" + hostName;
-        }
-        resource += "@" + realm;
-        return resource;
-    }
-
-    private toDate(epoch: string): Date {
-        let tmp = parseInt(epoch, 10);
-        if (tmp < 10000000000) {
-            tmp *= 1000;
-        }
-        let d = new Date();
-        d.setTime(tmp);
-        return d;
     }
 }

--- a/tests/test-config.test.ts
+++ b/tests/test-config.test.ts
@@ -7,7 +7,7 @@ import { Web } from "../src/sharepoint/rest/webs";
 import * as chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 
-export let testSettings = Util.extend(global.settings.testing, { webUrl: ""  });
+export let testSettings = Util.extend(global.settings.testing, { webUrl: "" });
 
 before(function (done: MochaDone) {
 
@@ -18,9 +18,11 @@ before(function (done: MochaDone) {
     if (testSettings.enableWebTests) {
 
         pnp.setup({
+            headers: {
+                "Accept": "application/json;odata=verbose",
+            },
             nodeClientOptions: {
-                clientId: testSettings.clientId,
-                clientSecret: testSettings.clientSecret,
+                credentials: testSettings.credentials,
                 siteUrl: testSettings.siteUrl,
             },
         });
@@ -41,18 +43,18 @@ before(function (done: MochaDone) {
 
             // re-setup the node client to use the new web
             pnp.setup({
-                // headers: {
-                //     "Accept": "application/json;odata=verbose",
-                // },
+                    headers: {
+                    "Accept": "application/json;odata=verbose",
+                },
                 nodeClientOptions: {
-                    clientId: testSettings.clientId,
-                    clientSecret: testSettings.clientSecret,
-                    siteUrl: url,
+                    credentials: testSettings.credentials,
+                    siteUrl: testSettings.siteUrl,
                 },
             });
 
             done();
-        });
+        })
+            .catch(done);
     } else {
         done();
     }
@@ -72,9 +74,9 @@ export function cleanUpAllSubsites() {
             let web = new Web(element["odata.id"], "");
             web.webs.select("Title").get().then((sw: any[]) => {
                 return Promise.all(sw.map((value, index, arr) => {
-                        let web2 = new Web(value["odata.id"], "");
-                        return web2.delete();
-                    }));
+                    let web2 = new Web(value["odata.id"], "");
+                    return web2.delete();
+                }));
             }).then(() => { web.delete(); });
         });
     }).catch(e => console.log("Error: " + JSON.stringify(e)));

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,7 @@
 {
-  "dependencies": {},
+  "dependencies": {
+    "node-sp-auth": "npm:node-sp-auth"
+  },
   "devDependencies": {},
   "globalDependencies": {
     "chai": "github:DefinitelyTyped/DefinitelyTyped/chai/chai.d.ts#9c25433c84251bfe72bf0030a95edbbb2c81c9d5",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    |  yes

This PR adds support for `nodefetchclient` to use [`node-sp-auth`](https://github.com/s-KaiNet/node-sp-auth) as authentication provider for nodejs. Now you are not limited in testing to SharePoint Online, you can test against on-premise with addin-only, user credentials or adfs.   
Sample integration of `pnp-js-core` with nodejs without modifying `pnp-js-core` sources you can find [here](https://github.com/s-KaiNet/node-pnpjs-sample)   

In this PR also addressed issue when running library in on-premise environment from nodejs - you need to provide default header `'accept': 'application/json;odata=verbose'` instead of just `application/json` like currently in `httpclient.ts`.    
